### PR TITLE
(circe): encoder + decoder based approach

### DIFF
--- a/src/main/scala/scraml/ModelGen.scala
+++ b/src/main/scala/scraml/ModelGen.scala
@@ -86,14 +86,14 @@ final case class ModelGenContext(
 
   lazy val anyTypeName: String = params.jsonSupport.map(_.jsonType).getOrElse("Any")
 
-  def getSubTypes: Iterator[AnyType] = {
+  lazy val getSubTypes: List[AnyType] = {
     objectType.getSubTypes.asScala.filter(_.getName != objectType.getName).iterator ++
       api.scalaExtends
         .find { case (_, typeValue) =>
           typeValue.getName == objectType.getName
         }
         .flatMap(entry => api.typesByName.get(entry._1))
-  }
+  }.toList
 
   lazy val typeProperties: Seq[Property] = RMFUtil.typeProperties(objectType).toSeq
   lazy val isSealed: Boolean = getSubTypes.forall(getPackageName(_).contains(packageName))

--- a/src/main/scala/scraml/RMFUtil.scala
+++ b/src/main/scala/scraml/RMFUtil.scala
@@ -18,9 +18,9 @@ object RMFUtil {
     from.getAnnotation(name)
   )
 
-  private def discriminators(aType: AnyType): List[String] = aType match {
+  def discriminators(aType: AnyType): List[String] = aType match {
     case objectType: ObjectType =>
-      List(objectType.getDiscriminator) ++ Option(aType.getType)
+      Option(objectType.getDiscriminator).toList ++ Option(aType.getType)
         .map(discriminators)
         .getOrElse(List.empty)
     case _ => List.empty

--- a/src/main/scala/scraml/libs/CirceJsonSupport.scala
+++ b/src/main/scala/scraml/libs/CirceJsonSupport.scala
@@ -1,11 +1,9 @@
 package scraml.libs
 
-import io.vrap.rmf.raml.model.modules.Api
 import scraml.LibrarySupport._
 import scraml.MetaUtil.packageTerm
-import scraml.ModelGen.isSingleton
 import scraml.RMFUtil.getAnnotation
-import scraml.{DefnWithCompanion, LibrarySupport, ModelGenContext, RMFUtil}
+import scraml.{DefnWithCompanion, LibrarySupport, ModelGen, ModelGenContext, RMFUtil}
 import io.vrap.rmf.raml.model.types.{AnyType, ObjectType, StringType}
 
 object CirceJsonSupport extends LibrarySupport {
@@ -48,30 +46,13 @@ object CirceJsonSupport extends LibrarySupport {
   private def discriminatorValue(aType: ObjectType): String =
     Option(aType.getDiscriminatorValue).getOrElse(aType.getName.toLowerCase)
 
-  private def typeEncoder(context: ModelGenContext): Defn.Def = {
-    val subTypes         = context.getSubTypes
-    val typeName         = context.objectType.getName
-    val discriminatorOpt = discriminator(context.objectType)
+  private def typeEncoder(context: ModelGenContext): Defn.Val = {
+    val subTypes = context.getSubTypes
+    val typeName = context.objectType.getName
 
-    Defn.Def(
-      List(Mod.Implicit()),
-      Term.Name("encodeAll"),
-      Nil,
-      paramss = List(
-        subTypes.flatMap {
-          case subType: ObjectType
-            if !isSingleton(subType, context.anyTypeName) => // filter out case objects
-            Some(
-              Term.Param(
-                List(Mod.Implicit()),
-                Term.Name(s"${subType.getName}Encoder"),
-                Some(Type.Apply(Type.Name("Encoder"), List(Type.Name(subType.getName)))),
-                None
-              )
-            )
-          case _ => None
-        }
-      ),
+    Defn.Val(
+      List(Mod.Implicit(), Mod.Lazy()),
+      List(Pat.Var(Term.Name("encoder"))),
       Some(Type.Apply(Type.Name("Encoder"), List(Type.Name(typeName)))),
       Term.NewAnonymous(
         Template(
@@ -98,75 +79,20 @@ object CirceJsonSupport extends LibrarySupport {
               Some(Type.Name("Json")),
               Term.Match(
                 Term.Name(typeName.toLowerCase),
-                subTypes.map {
-                  case subType: ObjectType
-                    if discriminatorOpt.isDefined && !isSingleton(subType, context.anyTypeName) =>
-                    Case(
-                      Pat.Typed(
-                        Pat.Var(Term.Name(subType.getName.toLowerCase)),
-                        Type.Name(subType.getName)
-                      ),
-                      None,
-                      Term.Apply(
-                        Term.Select(
-                          Term.Apply(
-                            Term.Name(s"${subType.getName}Encoder"),
-                            List(Term.Name(subType.getName.toLowerCase))
-                          ),
-                          Term.Name("mapObject")
-                        ),
-                        List(
-                          Term.Apply(
-                            Term.Select(Term.Placeholder(), Term.Name("add")),
-                            List(
-                              Lit.String(discriminatorOpt.getOrElse("type")),
-                              Term.Apply(
-                                packageTerm("Json.fromString"),
-                                List(Lit.String(discriminatorValue(subType)))
-                              )
-                            )
-                          )
-                        )
-                      )
+                subTypes.map { case subType: ObjectType =>
+                  Case(
+                    Pat.Typed(
+                      Pat.Var(Term.Name(subType.getName.toLowerCase)),
+                      if (ModelGen.isSingleton(subType, context.anyTypeName))
+                        Type.Singleton(Term.Name(subType.getName))
+                      else Type.Name(subType.getName)
+                    ),
+                    None,
+                    Term.Apply(
+                      packageTerm(s"${subType.getName}.encoder"),
+                      List(Term.Name(subType.getName.toLowerCase))
                     )
-                  case subType: ObjectType
-                    if discriminatorOpt.isEmpty && !isSingleton(subType, context.anyTypeName) =>
-                    Case(
-                      Pat.Typed(
-                        Pat.Var(Term.Name(subType.getName.toLowerCase)),
-                        Type.Name(subType.getName)
-                      ),
-                      None,
-                      Term.Apply(
-                        Term.Name(s"${subType.getName}Encoder"),
-                        List(Term.Name(subType.getName.toLowerCase))
-                      )
-                    )
-                  case subType: ObjectType => // case object
-                    Case(
-                      Term.Name(subType.getName),
-                      None,
-                      Term.Apply(
-                        Term.Select(Term.Name("Json"), Term.Name("obj")),
-                        List(
-                          Term.ApplyInfix(
-                            Lit.String(
-                              discriminatorOpt.getOrElse("type")
-                            ),
-                            Term.Name("->"),
-                            Nil,
-                            List(
-                              Term.Apply(
-                                Term.Select(Term.Name("Json"), Term.Name("fromString")),
-                                List(
-                                  Lit.String(discriminatorValue(subType))
-                                )
-                              )
-                            )
-                          )
-                        )
-                      )
-                    )
+                  )
                 },
                 Nil
               )
@@ -178,19 +104,20 @@ object CirceJsonSupport extends LibrarySupport {
     )
   }
 
-  private def typeDecoder(firstSubType: AnyType, context: ModelGenContext): Defn.Def = {
+  private def typeDecoder(firstSubType: AnyType, context: ModelGenContext): Defn.Val = {
     val subTypes         = context.getSubTypes
     val typeName         = context.objectType.getName
     val discriminatorOpt = discriminator(context.objectType)
     val decode: Term = if (discriminatorOpt.isEmpty) {
       val initRead: String =
         q"""
-            ${Term.Name(s"${firstSubType.getName}Decoder")}.tryDecode(c)
+            ${packageTerm(s"${firstSubType.getName}.decoder")}.tryDecode(c)
             """.toString
 
       val trySubtypes = subTypes.drop(1).foldLeft(initRead) { case (acc, next) =>
-        val nextRead = q"""fold(_ => ${Term
-          .Name(s"${next.getName}Decoder")}.tryDecode(c), Right(_))""".toString
+        val nextRead = q"""fold(_ => ${packageTerm(
+          s"${next.getName}.decoder"
+        )}.tryDecode(c), Right(_))""".toString
         s"$acc.$nextRead"
       }
 
@@ -207,21 +134,16 @@ object CirceJsonSupport extends LibrarySupport {
           ),
           List(Type.Name("String"))
         ),
-        subTypes.map {
-          case subType: ObjectType if !isSingleton(subType, context.anyTypeName) =>
-            Case(
-              Pat
-                .Extract(Term.Name("Right"), List(Lit.String(discriminatorValue(subType)))),
-              None,
-              Term.Apply(Term.Name(s"${subType.getName}Decoder"), List(Term.Name("c")))
+        subTypes.map { case subType: ObjectType =>
+          Case(
+            Pat
+              .Extract(Term.Name("Right"), List(Lit.String(discriminatorValue(subType)))),
+            None,
+            Term.Apply(
+              Term.Select(Term.Name(subType.getName), Term.Name("decoder")),
+              List(Term.Name("c"))
             )
-          case subType: ObjectType => // case object
-            Case(
-              Pat
-                .Extract(Term.Name("Right"), List(Lit.String(discriminatorValue(subType)))),
-              None,
-              Term.Apply(Term.Name("Right"), List(Term.Name(subType.getName)))
-            )
+          )
         } ++ List(
           Case(
             Pat.Var(Term.Name("other")),
@@ -247,24 +169,9 @@ object CirceJsonSupport extends LibrarySupport {
         Nil
       )
 
-    Defn.Def(
-      List(Mod.Implicit()),
-      Term.Name("decodeAll"),
-      Nil,
-      List(
-        subTypes.flatMap {
-          case subType: ObjectType if !isSingleton(subType, context.anyTypeName) =>
-            Some(
-              Term.Param(
-                List(Mod.Implicit()),
-                Term.Name(s"${subType.getName}Decoder"),
-                Some(Type.Apply(Type.Name("Decoder"), List(Type.Name(subType.getName)))),
-                None
-              )
-            )
-          case _ => None
-        }
-      ),
+    Defn.Val(
+      List(Mod.Implicit(), Mod.Lazy()),
+      List(Pat.Var(Term.Name("decoder"))),
       Some(Type.Apply(Type.Name("Decoder"), List(Type.Name(typeName)))),
       Term.NewAnonymous(
         Template(
@@ -311,13 +218,50 @@ object CirceJsonSupport extends LibrarySupport {
 
   private def deriveJson(objectType: ObjectType): List[Stat] =
     if (shouldDeriveJson(objectType)) {
+      val encoderDef: Defn.Val = discriminator(objectType)
+        .map { _ =>
+          Defn.Val(
+            List(Mod.Implicit(), Mod.Lazy()),
+            List(Pat.Var(Term.Name("encoder"))),
+            Some(Type.Apply(Type.Name("Encoder"), List(Type.Name(objectType.getName)))),
+            rhs = Term.Apply(
+              Term.Select(
+                Term.ApplyType(Term.Name("deriveEncoder"), List(Type.Name(objectType.getName))),
+                Term.Name("mapJsonObject")
+              ),
+              List(
+                Term.Apply(
+                  Term.Select(Term.Placeholder(), Term.Name("add")),
+                  List(
+                    Lit.String("type"),
+                    Term.Apply(
+                      Term.Select(Term.Name("Json"), Term.Name("fromString")),
+                      List(Lit.String(discriminatorValue(objectType)))
+                    )
+                  )
+                )
+              )
+            )
+          )
+        }
+        .getOrElse(
+          q"""
+           implicit lazy val encoder: Encoder[${Type
+            .Name(objectType.getName)}] = deriveEncoder[${Type.Name(
+            objectType.getName
+          )}]
+         """
+        )
+
       q"""import io.circe._
           import io.circe.generic.semiauto._
 
-          implicit lazy val json: Codec[${Type.Name(objectType.getName)}] = deriveCodec[${Type.Name(
+          implicit lazy val decoder: Decoder[${Type.Name(
+        objectType.getName
+      )}] = deriveDecoder[${Type.Name(
         objectType.getName
       )}]
-      """.stats
+      """.stats ++ List(encoderDef)
     } else List.empty
 
   private def mapTypeCodec(context: ModelGenContext): List[Stat] =
@@ -330,27 +274,35 @@ object CirceJsonSupport extends LibrarySupport {
             Type.Apply(Type.Name("Option"), List(mapApply))
           } else mapApply
 
-          q"""import io.circe.syntax._
-          import io.circe._
-          import io.circe.Decoder.Result
+          q"""
+        import io.circe._
+        import io.circe.syntax._
+        import io.circe.generic.semiauto._
+        import io.circe.Decoder.Result
 
-          implicit lazy val json: Codec[${Type.Name(context.objectType.getName)}] = new Codec[${Type
-            .Name(context.objectType.getName)}] {
-            override def apply(a: ${Type.Name(context.objectType.getName)}): Json =
-              a.values.asJson
+        implicit lazy val decoder: Decoder[${Type.Name(
+            context.objectType.getName
+          )}] = new Decoder[${Type.Name(context.objectType.getName)}] {
             override def apply(c: HCursor): Result[${Type.Name(context.objectType.getName)}] =
               c.as[$decodeType].map(${Term.Name(
             context.objectType.getName
           )}.apply)
-          }
-        """.stats
+        }
+        implicit lazy val encoder: Encoder[${Type.Name(
+            context.objectType.getName
+          )}] = new Encoder[${Type.Name(context.objectType.getName)}] {
+            override def apply(a: ${Type.Name(context.objectType.getName)}): Json =
+              a.values.asJson
+        }
+         """.stats
+
         case None => List.empty
       }
 
     } else List.empty
 
   override def modifyClass(classDef: Defn.Class, companion: Option[Defn.Object])(
-    context: ModelGenContext
+      context: ModelGenContext
   ): DefnWithCompanion[Defn.Class] =
     DefnWithCompanion(
       classDef,
@@ -363,22 +315,57 @@ object CirceJsonSupport extends LibrarySupport {
     )
 
   override def modifyTrait(traitDef: Defn.Trait, companion: Option[Defn.Object])(
-    context: ModelGenContext
+      context: ModelGenContext
   ): DefnWithCompanion[Defn.Trait] =
     DefnWithCompanion(
       defn = traitDef,
       companion = companion.map(appendObjectStats(_, deriveJsonTypeSwitch(context)))
     )
 
-  override def modifyPackageObject(api: Api): Pkg.Object => Pkg.Object =
+  override def modifyObject(objectDef: Defn.Object)(
+      context: ModelGenContext
+  ): DefnWithCompanion[Defn.Object] =
+    DefnWithCompanion(
+      appendObjectStats(
+        objectDef,
+        q"""
+        import io.circe._
+        import io.circe.generic.semiauto._
+        import io.circe.Decoder.Result
+
+        implicit lazy val decoder: Decoder[${Type.Singleton(
+          Term.Name(context.objectType.getName)
+        )}] = new Decoder[${Type.Singleton(Term.Name(context.objectType.getName))}] {
+          override def apply(c: HCursor): Result[${Type.Singleton(
+          Term.Name(context.objectType.getName)
+        )}] = c.downField("type").as[String] match {
+            case Right(${discriminatorValue(context.objectType)}) =>
+              Right(${Term.Name(context.objectType.getName)})
+            case other =>
+              Left(DecodingFailure(s"unknown type: $$other", c.history))
+          }
+        }
+        implicit lazy val encoder: Encoder[${Type.Singleton(
+          Term.Name(context.objectType.getName)
+        )}] = new Encoder[${Type.Singleton(Term.Name(context.objectType.getName))}] {
+          override def apply(a: ${Type.Singleton(
+          Term.Name(context.objectType.getName)
+        )}): Json = Json.obj("type" -> Json.fromString(${discriminatorValue(context.objectType)}))
+        }
+         """.stats
+      ),
+      None
+    )
+
+  override def modifyPackageObject: Pkg.Object => Pkg.Object =
     appendPkgObjectStats(_, eitherCodec)
 
   override def modifyEnum(
-                           enumType: StringType
-                         )(enumTrait: Defn.Trait, companion: Option[Defn.Object]): DefnWithCompanion[Defn.Trait] = {
+      enumType: StringType
+  )(enumTrait: Defn.Trait, companion: Option[Defn.Object]): DefnWithCompanion[Defn.Trait] = {
     val enumDecode = Defn.Val(
-      List(Mod.Implicit()),
-      List(Pat.Var(Term.Name("decode"))),
+      List(Mod.Implicit(), Mod.Lazy()),
+      List(Pat.Var(Term.Name("decoder"))),
       Some(Type.Apply(Type.Name("Decoder"), List(Type.Name(enumType.getName)))),
       Term.Apply(
         Term.Select(
@@ -417,8 +404,8 @@ object CirceJsonSupport extends LibrarySupport {
     )
 
     val enumEncode = Defn.Val(
-      List(Mod.Implicit()),
-      List(Pat.Var(Term.Name("encode"))),
+      List(Mod.Implicit(), Mod.Lazy()),
+      List(Pat.Var(Term.Name("encoder"))),
       Some(Type.Apply(Type.Name("Encoder"), List(Type.Name(enumType.getName)))),
       Term.Apply(
         Term.Select(

--- a/src/main/scala/scraml/libs/CirceJsonSupport.scala
+++ b/src/main/scala/scraml/libs/CirceJsonSupport.scala
@@ -1,12 +1,12 @@
 package scraml.libs
 
+import io.vrap.rmf.raml.model.modules.Api
 import scraml.LibrarySupport._
 import scraml.MetaUtil.packageTerm
 import scraml.ModelGen.isSingleton
 import scraml.RMFUtil.getAnnotation
-import scraml.{DefnWithCompanion, LibrarySupport, ModelGenContext}
-
-import io.vrap.rmf.raml.model.types.{ObjectType, StringType}
+import scraml.{DefnWithCompanion, LibrarySupport, ModelGenContext, RMFUtil}
+import io.vrap.rmf.raml.model.types.{AnyType, ObjectType, StringType}
 
 object CirceJsonSupport extends LibrarySupport {
   import scala.meta._
@@ -35,260 +35,274 @@ object CirceJsonSupport extends LibrarySupport {
       }
      """.stats
 
-  private def deriveJsonTypeSwitch(context: ModelGenContext): List[Stat] =
-    if (shouldDeriveJson(context.objectType)) {
-      val typeName = context.objectType.getName
-      val subTypes = context.getSubTypes.toList
+  private def discriminator(aType: ObjectType): Option[String] =
+    RMFUtil.discriminators(aType) match {
+      case Nil           => None
+      case single :: Nil => Some(single)
+      case _ =>
+        throw new IllegalArgumentException(
+          "only single discriminator should be defined in type hierarchy"
+        )
+    }
 
-      subTypes.headOption
-        .map { firstSubType =>
-          val encodeAll =
-            Defn.Def(
-              List(Mod.Implicit()),
-              Term.Name("encodeAll"),
-              Nil,
-              List(
-                subTypes.flatMap {
-                  case subType: ObjectType
-                      if !isSingleton(subType, context.anyTypeName) => // filter out case objects
-                    Some(
-                      Term.Param(
-                        List(Mod.Implicit()),
-                        Term.Name(s"${subType.getName}Encoder"),
-                        Some(Type.Apply(Type.Name("Encoder"), List(Type.Name(subType.getName)))),
-                        None
-                      )
-                    )
-                  case _ => None
-                }
-              ),
-              Some(Type.Apply(Type.Name("Encoder"), List(Type.Name(typeName)))),
-              Term.NewAnonymous(
-                Template(
-                  Nil,
-                  List(
-                    Init(Type.Apply(Type.Name("Encoder"), List(Type.Name(typeName))), Name(""), Nil)
-                  ),
-                  Self(Name(""), None),
-                  List(
-                    Defn.Def(
-                      List(Mod.Override()),
-                      Term.Name("apply"),
-                      Nil,
-                      List(
-                        List(
-                          Term.Param(
-                            Nil,
-                            Term.Name(typeName.toLowerCase),
-                            Some(Type.Name(typeName)),
-                            None
-                          )
-                        )
-                      ),
-                      Some(Type.Name("Json")),
-                      Term.Match(
-                        Term.Name(typeName.toLowerCase),
-                        subTypes.map {
-                          case subType: ObjectType
-                              if Option(
-                                context.objectType.getDiscriminator
-                              ).isDefined && !isSingleton(subType, context.anyTypeName) =>
-                            Case(
-                              Pat.Typed(
-                                Pat.Var(Term.Name(subType.getName.toLowerCase)),
-                                Type.Name(subType.getName)
-                              ),
-                              None,
-                              Term.Apply(
-                                Term.Select(
-                                  Term.Apply(
-                                    Term.Name(s"${subType.getName}Encoder"),
-                                    List(Term.Name(subType.getName.toLowerCase))
-                                  ),
-                                  Term.Name("mapObject")
-                                ),
-                                List(
-                                  Term.Apply(
-                                    Term.Select(Term.Placeholder(), Term.Name("add")),
-                                    List(
-                                      Lit.String(context.objectType.getDiscriminator),
-                                      Term.Apply(
-                                        packageTerm("Json.fromString"),
-                                        List(Lit.String(subType.getDiscriminatorValue))
-                                      )
-                                    )
-                                  )
-                                )
-                              )
-                            )
-                          case subType: ObjectType
-                              if Option(
-                                context.objectType.getDiscriminator
-                              ).isEmpty && !isSingleton(subType, context.anyTypeName) =>
-                            Case(
-                              Pat.Typed(
-                                Pat.Var(Term.Name(subType.getName.toLowerCase)),
-                                Type.Name(subType.getName)
-                              ),
-                              None,
-                              Term.Apply(
-                                Term.Name(s"${subType.getName}Encoder"),
-                                List(Term.Name(subType.getName.toLowerCase))
-                              )
-                            )
-                          case subType: ObjectType => // case object
-                            Case(
-                              Term.Name(subType.getName),
-                              None,
-                              Term.Apply(
-                                Term.Select(Term.Name("Json"), Term.Name("obj")),
-                                List(
-                                  Term.ApplyInfix(
-                                    Lit.String(
-                                      Option(context.objectType.getDiscriminator).getOrElse("type")
-                                    ),
-                                    Term.Name("->"),
-                                    Nil,
-                                    List(
-                                      Term.Apply(
-                                        Term.Select(Term.Name("Json"), Term.Name("fromString")),
-                                        List(
-                                          Lit.String(
-                                            Option(subType.getDiscriminatorValue)
-                                              .getOrElse(subType.getName)
-                                          )
-                                        )
-                                      )
-                                    )
-                                  )
-                                )
-                              )
-                            )
-                        },
-                        Nil
-                      )
-                    )
-                  ),
-                  Nil
-                )
+  private def discriminatorValue(aType: ObjectType): String =
+    Option(aType.getDiscriminatorValue).getOrElse(aType.getName.toLowerCase)
+
+  private def typeEncoder(context: ModelGenContext): Defn.Def = {
+    val subTypes         = context.getSubTypes
+    val typeName         = context.objectType.getName
+    val discriminatorOpt = discriminator(context.objectType)
+
+    Defn.Def(
+      List(Mod.Implicit()),
+      Term.Name("encodeAll"),
+      Nil,
+      paramss = List(
+        subTypes.flatMap {
+          case subType: ObjectType
+            if !isSingleton(subType, context.anyTypeName) => // filter out case objects
+            Some(
+              Term.Param(
+                List(Mod.Implicit()),
+                Term.Name(s"${subType.getName}Encoder"),
+                Some(Type.Apply(Type.Name("Encoder"), List(Type.Name(subType.getName)))),
+                None
               )
             )
+          case _ => None
+        }
+      ),
+      Some(Type.Apply(Type.Name("Encoder"), List(Type.Name(typeName)))),
+      Term.NewAnonymous(
+        Template(
+          Nil,
+          List(
+            Init(Type.Apply(Type.Name("Encoder"), List(Type.Name(typeName))), Name(""), Nil)
+          ),
+          Self(Name(""), None),
+          List(
+            Defn.Def(
+              List(Mod.Override()),
+              Term.Name("apply"),
+              Nil,
+              List(
+                List(
+                  Term.Param(
+                    Nil,
+                    Term.Name(typeName.toLowerCase),
+                    Some(Type.Name(typeName)),
+                    None
+                  )
+                )
+              ),
+              Some(Type.Name("Json")),
+              Term.Match(
+                Term.Name(typeName.toLowerCase),
+                subTypes.map {
+                  case subType: ObjectType
+                    if discriminatorOpt.isDefined && !isSingleton(subType, context.anyTypeName) =>
+                    Case(
+                      Pat.Typed(
+                        Pat.Var(Term.Name(subType.getName.toLowerCase)),
+                        Type.Name(subType.getName)
+                      ),
+                      None,
+                      Term.Apply(
+                        Term.Select(
+                          Term.Apply(
+                            Term.Name(s"${subType.getName}Encoder"),
+                            List(Term.Name(subType.getName.toLowerCase))
+                          ),
+                          Term.Name("mapObject")
+                        ),
+                        List(
+                          Term.Apply(
+                            Term.Select(Term.Placeholder(), Term.Name("add")),
+                            List(
+                              Lit.String(discriminatorOpt.getOrElse("type")),
+                              Term.Apply(
+                                packageTerm("Json.fromString"),
+                                List(Lit.String(discriminatorValue(subType)))
+                              )
+                            )
+                          )
+                        )
+                      )
+                    )
+                  case subType: ObjectType
+                    if discriminatorOpt.isEmpty && !isSingleton(subType, context.anyTypeName) =>
+                    Case(
+                      Pat.Typed(
+                        Pat.Var(Term.Name(subType.getName.toLowerCase)),
+                        Type.Name(subType.getName)
+                      ),
+                      None,
+                      Term.Apply(
+                        Term.Name(s"${subType.getName}Encoder"),
+                        List(Term.Name(subType.getName.toLowerCase))
+                      )
+                    )
+                  case subType: ObjectType => // case object
+                    Case(
+                      Term.Name(subType.getName),
+                      None,
+                      Term.Apply(
+                        Term.Select(Term.Name("Json"), Term.Name("obj")),
+                        List(
+                          Term.ApplyInfix(
+                            Lit.String(
+                              discriminatorOpt.getOrElse("type")
+                            ),
+                            Term.Name("->"),
+                            Nil,
+                            List(
+                              Term.Apply(
+                                Term.Select(Term.Name("Json"), Term.Name("fromString")),
+                                List(
+                                  Lit.String(discriminatorValue(subType))
+                                )
+                              )
+                            )
+                          )
+                        )
+                      )
+                    )
+                },
+                Nil
+              )
+            )
+          ),
+          Nil
+        )
+      )
+    )
+  }
 
-          val decode: Term = if (Option(context.objectType.getDiscriminator).isEmpty) {
-            val initRead: String =
-              q"""
+  private def typeDecoder(firstSubType: AnyType, context: ModelGenContext): Defn.Def = {
+    val subTypes         = context.getSubTypes
+    val typeName         = context.objectType.getName
+    val discriminatorOpt = discriminator(context.objectType)
+    val decode: Term = if (discriminatorOpt.isEmpty) {
+      val initRead: String =
+        q"""
             ${Term.Name(s"${firstSubType.getName}Decoder")}.tryDecode(c)
             """.toString
 
-            val trySubtypes = subTypes.drop(1).foldLeft(initRead) { case (acc, next) =>
-              val nextRead = q"""fold(_ => ${Term
-                .Name(s"${next.getName}Decoder")}.tryDecode(c), Right(_))""".toString
-              s"$acc.$nextRead"
-            }
+      val trySubtypes = subTypes.drop(1).foldLeft(initRead) { case (acc, next) =>
+        val nextRead = q"""fold(_ => ${Term
+          .Name(s"${next.getName}Decoder")}.tryDecode(c), Right(_))""".toString
+        s"$acc.$nextRead"
+      }
 
-            trySubtypes.parse[Term].get
-          } else
-            Term.Match(
-              Term.ApplyType(
-                Term.Select(
-                  Term.Apply(
-                    Term.Select(Term.Name("c"), Term.Name("downField")),
-                    List(Lit.String(context.objectType.getDiscriminator))
-                  ),
-                  Term.Name("as")
-                ),
-                List(Type.Name("String"))
-              ),
-              subTypes.map {
-                case subType: ObjectType if !isSingleton(subType, context.anyTypeName) =>
-                  Case(
-                    Pat
-                      .Extract(Term.Name("Right"), List(Lit.String(subType.getDiscriminatorValue))),
-                    None,
-                    Term.Apply(Term.Name(s"${subType.getName}Decoder"), List(Term.Name("c")))
-                  )
-                case subType: ObjectType => // case object
-                  Case(
-                    Pat
-                      .Extract(Term.Name("Right"), List(Lit.String(subType.getDiscriminatorValue))),
-                    None,
-                    Term.Apply(Term.Name("Right"), List(Term.Name(subType.getName)))
-                  )
-              } ++ List(
-                Case(
-                  Pat.Var(Term.Name("other")),
-                  None,
-                  Term.Apply(
-                    Term.Name("Left"),
-                    List(
-                      Term.Apply(
-                        Term.Name("DecodingFailure"),
-                        List(
-                          Term.Interpolate(
-                            Term.Name("s"),
-                            List(Lit.String("unknown discriminator: "), Lit.String("")),
-                            List(Term.Name("other"))
-                          ),
-                          Term.Select(Term.Name("c"), Term.Name("history"))
-                        )
-                      )
-                    )
-                  )
-                )
-              ),
-              Nil
+      trySubtypes.parse[Term].get
+    } else
+      Term.Match(
+        Term.ApplyType(
+          Term.Select(
+            Term.Apply(
+              Term.Select(Term.Name("c"), Term.Name("downField")),
+              discriminatorOpt.map(Lit.String(_)).toList
+            ),
+            Term.Name("as")
+          ),
+          List(Type.Name("String"))
+        ),
+        subTypes.map {
+          case subType: ObjectType if !isSingleton(subType, context.anyTypeName) =>
+            Case(
+              Pat
+                .Extract(Term.Name("Right"), List(Lit.String(discriminatorValue(subType)))),
+              None,
+              Term.Apply(Term.Name(s"${subType.getName}Decoder"), List(Term.Name("c")))
             )
-
-          val decodeAll =
-            Defn.Def(
-              List(Mod.Implicit()),
-              Term.Name("decodeAll"),
-              Nil,
+          case subType: ObjectType => // case object
+            Case(
+              Pat
+                .Extract(Term.Name("Right"), List(Lit.String(discriminatorValue(subType)))),
+              None,
+              Term.Apply(Term.Name("Right"), List(Term.Name(subType.getName)))
+            )
+        } ++ List(
+          Case(
+            Pat.Var(Term.Name("other")),
+            None,
+            Term.Apply(
+              Term.Name("Left"),
               List(
-                subTypes.flatMap {
-                  case subType: ObjectType if !isSingleton(subType, context.anyTypeName) =>
-                    Some(
-                      Term.Param(
-                        List(Mod.Implicit()),
-                        Term.Name(s"${subType.getName}Decoder"),
-                        Some(Type.Apply(Type.Name("Decoder"), List(Type.Name(subType.getName)))),
-                        None
-                      )
-                    )
-                  case _ => None
-                }
-              ),
-              Some(Type.Apply(Type.Name("Decoder"), List(Type.Name(typeName)))),
-              Term.NewAnonymous(
-                Template(
-                  Nil,
+                Term.Apply(
+                  Term.Name("DecodingFailure"),
                   List(
-                    Init(Type.Apply(Type.Name("Decoder"), List(Type.Name(typeName))), Name(""), Nil)
-                  ),
-                  Self(Name(""), None),
-                  List(
-                    Defn.Def(
-                      List(Mod.Override()),
-                      Term.Name("apply"),
-                      Nil,
-                      List(List(Term.Param(Nil, Term.Name("c"), Some(Type.Name("HCursor")), None))),
-                      Some(Type.Apply(Type.Name("Result"), List(Type.Name(typeName)))),
-                      decode
-                    )
-                  ),
-                  Nil
+                    Term.Interpolate(
+                      Term.Name("s"),
+                      List(Lit.String("unknown discriminator: "), Lit.String("")),
+                      List(Term.Name("other"))
+                    ),
+                    Term.Select(Term.Name("c"), Term.Name("history"))
+                  )
                 )
               )
             )
+          )
+        ),
+        Nil
+      )
 
+    Defn.Def(
+      List(Mod.Implicit()),
+      Term.Name("decodeAll"),
+      Nil,
+      List(
+        subTypes.flatMap {
+          case subType: ObjectType if !isSingleton(subType, context.anyTypeName) =>
+            Some(
+              Term.Param(
+                List(Mod.Implicit()),
+                Term.Name(s"${subType.getName}Decoder"),
+                Some(Type.Apply(Type.Name("Decoder"), List(Type.Name(subType.getName)))),
+                None
+              )
+            )
+          case _ => None
+        }
+      ),
+      Some(Type.Apply(Type.Name("Decoder"), List(Type.Name(typeName)))),
+      Term.NewAnonymous(
+        Template(
+          Nil,
+          List(
+            Init(Type.Apply(Type.Name("Decoder"), List(Type.Name(typeName))), Name(""), Nil)
+          ),
+          Self(Name(""), None),
+          List(
+            Defn.Def(
+              List(Mod.Override()),
+              Term.Name("apply"),
+              Nil,
+              List(List(Term.Param(Nil, Term.Name("c"), Some(Type.Name("HCursor")), None))),
+              Some(Type.Apply(Type.Name("Result"), List(Type.Name(typeName)))),
+              decode
+            )
+          ),
+          Nil
+        )
+      )
+    )
+  }
+
+  private def deriveJsonTypeSwitch(context: ModelGenContext): List[Stat] =
+    if (shouldDeriveJson(context.objectType)) {
+      val subTypes: List[AnyType] = context.getSubTypes
+
+      subTypes.headOption
+        .map { firstSubType =>
           val jsonStats =
             q"""
           import io.circe.Decoder.Result
           import io.circe._
 
-          $decodeAll
+          ${typeDecoder(firstSubType, context)}
 
-          $encodeAll
+          ${typeEncoder(context)}
         """.stats
           jsonStats
         }
@@ -336,7 +350,7 @@ object CirceJsonSupport extends LibrarySupport {
     } else List.empty
 
   override def modifyClass(classDef: Defn.Class, companion: Option[Defn.Object])(
-      context: ModelGenContext
+    context: ModelGenContext
   ): DefnWithCompanion[Defn.Class] =
     DefnWithCompanion(
       classDef,
@@ -349,19 +363,19 @@ object CirceJsonSupport extends LibrarySupport {
     )
 
   override def modifyTrait(traitDef: Defn.Trait, companion: Option[Defn.Object])(
-      context: ModelGenContext
+    context: ModelGenContext
   ): DefnWithCompanion[Defn.Trait] =
     DefnWithCompanion(
       defn = traitDef,
       companion = companion.map(appendObjectStats(_, deriveJsonTypeSwitch(context)))
     )
 
-  override def modifyPackageObject: Pkg.Object => Pkg.Object =
+  override def modifyPackageObject(api: Api): Pkg.Object => Pkg.Object =
     appendPkgObjectStats(_, eitherCodec)
 
   override def modifyEnum(
-      enumType: StringType
-  )(enumTrait: Defn.Trait, companion: Option[Defn.Object]): DefnWithCompanion[Defn.Trait] = {
+                           enumType: StringType
+                         )(enumTrait: Defn.Trait, companion: Option[Defn.Object]): DefnWithCompanion[Defn.Trait] = {
     val enumDecode = Defn.Val(
       List(Mod.Implicit()),
       List(Pat.Var(Term.Name("decode"))),

--- a/src/sbt-test/sbt-scraml/json/api/grandchild.raml
+++ b/src/sbt-test/sbt-scraml/json/api/grandchild.raml
@@ -1,0 +1,19 @@
+#%RAML 1.0 DataType
+(package): DataTypes
+(docs-uri): "https://example.org/grandchild-type"
+displayName: GrandchildType
+type: IntermediateType
+(scala-derive-json): true
+discriminatorValue: grandchild
+properties:
+  foo?:
+    type: string
+  customTypeProp:
+    (scala-type): "scala.math.BigDecimal"
+    type: number
+  customArrayTypeProp:
+    (scala-array-type): "Vector"
+    type: array
+    (scala-type): "scala.math.BigDecimal"
+    items:
+      type: object

--- a/src/sbt-test/sbt-scraml/json/api/intermediate.raml
+++ b/src/sbt-test/sbt-scraml/json/api/intermediate.raml
@@ -1,0 +1,6 @@
+#%RAML 1.0 DataType
+(package): DataTypes
+(docs-uri): "https://example.org/intermediate-type"
+displayName: IntermediateType
+type: BaseType
+(scala-derive-json): true

--- a/src/sbt-test/sbt-scraml/json/api/types.raml
+++ b/src/sbt-test/sbt-scraml/json/api/types.raml
@@ -2,6 +2,8 @@ NoDiscriminatorBase: !include nodiscriminatorbase.raml
 NoDiscriminatorSub1: !include nodiscriminatorsub1.raml
 NoDiscriminatorSub2: !include nodiscriminatorsub2.raml
 BaseType: !include basetype.raml
+IntermediateType: !include intermediate.raml
+GrandchildType: !include grandchild.raml
 DataType: !include datatype.raml
 EmptyBase: !include emptybase.raml
 NoProps: !include noprops.raml

--- a/src/sbt-test/sbt-scraml/json/src/main/scala/scraml/JsonTest.scala
+++ b/src/sbt-test/sbt-scraml/json/src/main/scala/scraml/JsonTest.scala
@@ -5,9 +5,7 @@ import io.circe.syntax._
 
 object JsonTest extends App {
   val grandchild = GrandchildType(id = "someid", customTypeProp = scala.math.BigDecimal(42))
-  val imCodec = implicitly[Codec[IntermediateType]]
 
-  println(grandchild.asJson)
-  println(im(grandchild))
+  assert(grandchild.asJson == IntermediateType.encoder(grandchild))
 }
 

--- a/src/sbt-test/sbt-scraml/json/src/main/scala/scraml/JsonTest.scala
+++ b/src/sbt-test/sbt-scraml/json/src/main/scala/scraml/JsonTest.scala
@@ -1,0 +1,13 @@
+package scraml
+
+import io.circe._
+import io.circe.syntax._
+
+object JsonTest extends App {
+  val grandchild = GrandchildType(id = "someid", customTypeProp = scala.math.BigDecimal(42))
+  val imCodec = implicitly[Codec[IntermediateType]]
+
+  println(grandchild.asJson)
+  println(im(grandchild))
+}
+

--- a/src/sbt-test/sbt-scraml/json/test
+++ b/src/sbt-test/sbt-scraml/json/test
@@ -1,1 +1,2 @@
 > compile
+> run

--- a/src/test/scala/scraml/CirceJsonSupportSpec.scala
+++ b/src/test/scala/scraml/CirceJsonSupportSpec.scala
@@ -26,13 +26,13 @@ class CirceJsonSupportSpec extends AnyFlatSpec with Matchers {
           Some(s"""object NoDiscriminatorBase {
                   |  import io.circe.Decoder.Result
                   |  import io.circe._
-                  |  implicit def decodeAll(implicit NoDiscriminatorSub1Decoder: Decoder[NoDiscriminatorSub1], NoDiscriminatorSub2Decoder: Decoder[NoDiscriminatorSub2]): Decoder[NoDiscriminatorBase] = new Decoder[NoDiscriminatorBase] { override def apply(c: HCursor): Result[NoDiscriminatorBase] = NoDiscriminatorSub1Decoder.tryDecode(c).fold(_ => NoDiscriminatorSub2Decoder.tryDecode(c), Right(_)) }
-                  |  implicit def encodeAll(implicit NoDiscriminatorSub1Encoder: Encoder[NoDiscriminatorSub1], NoDiscriminatorSub2Encoder: Encoder[NoDiscriminatorSub2]): Encoder[NoDiscriminatorBase] = new Encoder[NoDiscriminatorBase] {
+                  |  implicit lazy val decoder: Decoder[NoDiscriminatorBase] = new Decoder[NoDiscriminatorBase] { override def apply(c: HCursor): Result[NoDiscriminatorBase] = NoDiscriminatorSub1.decoder.tryDecode(c).fold(_ => NoDiscriminatorSub2.decoder.tryDecode(c), Right(_)) }
+                  |  implicit lazy val encoder: Encoder[NoDiscriminatorBase] = new Encoder[NoDiscriminatorBase] {
                   |    override def apply(nodiscriminatorbase: NoDiscriminatorBase): Json = nodiscriminatorbase match {
                   |      case nodiscriminatorsub1: NoDiscriminatorSub1 =>
-                  |        NoDiscriminatorSub1Encoder(nodiscriminatorsub1)
+                  |        NoDiscriminatorSub1.encoder(nodiscriminatorsub1)
                   |      case nodiscriminatorsub2: NoDiscriminatorSub2 =>
-                  |        NoDiscriminatorSub2Encoder(nodiscriminatorsub2)
+                  |        NoDiscriminatorSub2.encoder(nodiscriminatorsub2)
                   |    }
                   |  }
                   |}""".stripMargin)
@@ -45,22 +45,22 @@ class CirceJsonSupportSpec extends AnyFlatSpec with Matchers {
         baseType.source.companion.map(_.toString()) should be(Some(s"""object BaseType {
                                                                       |  import io.circe.Decoder.Result
                                                                       |  import io.circe._
-                                                                      |  implicit def decodeAll(implicit IntermediateTypeDecoder: Decoder[IntermediateType], DataTypeDecoder: Decoder[DataType]): Decoder[BaseType] = new Decoder[BaseType] {
+                                                                      |  implicit lazy val decoder: Decoder[BaseType] = new Decoder[BaseType] {
                                                                       |    override def apply(c: HCursor): Result[BaseType] = c.downField("type").as[String] match {
                                                                       |      case Right("intermediatetype") =>
-                                                                      |        IntermediateTypeDecoder(c)
+                                                                      |        IntermediateType.decoder(c)
                                                                       |      case Right("data") =>
-                                                                      |        DataTypeDecoder(c)
+                                                                      |        DataType.decoder(c)
                                                                       |      case other =>
                                                                       |        Left(DecodingFailure(s"unknown discriminator: $$other", c.history))
                                                                       |    }
                                                                       |  }
-                                                                      |  implicit def encodeAll(implicit IntermediateTypeEncoder: Encoder[IntermediateType], DataTypeEncoder: Encoder[DataType]): Encoder[BaseType] = new Encoder[BaseType] {
+                                                                      |  implicit lazy val encoder: Encoder[BaseType] = new Encoder[BaseType] {
                                                                       |    override def apply(basetype: BaseType): Json = basetype match {
                                                                       |      case intermediatetype: IntermediateType =>
-                                                                      |        IntermediateTypeEncoder(intermediatetype).mapObject(_.add("type", Json.fromString("intermediatetype")))
+                                                                      |        IntermediateType.encoder(intermediatetype)
                                                                       |      case datatype: DataType =>
-                                                                      |        DataTypeEncoder(datatype).mapObject(_.add("type", Json.fromString("data")))
+                                                                      |        DataType.encoder(datatype)
                                                                       |    }
                                                                       |  }
                                                                       |}""".stripMargin))
@@ -74,55 +74,69 @@ class CirceJsonSupportSpec extends AnyFlatSpec with Matchers {
         )
         dataType.source.name should be("DataType")
         dataType.source.companion.map(_.toString()) should be(Some(s"""object DataType {
-             |  import io.circe._
-             |  import io.circe.generic.semiauto._
-             |  implicit lazy val json: Codec[DataType] = deriveCodec[DataType]
-             |}""".stripMargin))
+                                                                      |  import io.circe._
+                                                                      |  import io.circe.generic.semiauto._
+                                                                      |  implicit lazy val decoder: Decoder[DataType] = deriveDecoder[DataType]
+                                                                      |  implicit lazy val encoder: Encoder[DataType] = deriveEncoder[DataType].mapJsonObject(_.add("type", Json.fromString("data")))
+                                                                      |}""".stripMargin))
 
         emptyBase.source.source.toString() should be("sealed trait EmptyBase")
         emptyBase.source.companion.map(_.toString()) should be(Some(s"""object EmptyBase {
-             |  import io.circe.Decoder.Result
+                                                                       |  import io.circe.Decoder.Result
+                                                                       |  import io.circe._
+                                                                       |  implicit lazy val decoder: Decoder[EmptyBase] = new Decoder[EmptyBase] {
+                                                                       |    override def apply(c: HCursor): Result[EmptyBase] = c.downField("type").as[String] match {
+                                                                       |      case Right("nope") =>
+                                                                       |        NoProps.decoder(c)
+                                                                       |      case other =>
+                                                                       |        Left(DecodingFailure(s"unknown discriminator: $$other", c.history))
+                                                                       |    }
+                                                                       |  }
+                                                                       |  implicit lazy val encoder: Encoder[EmptyBase] = new Encoder[EmptyBase] {
+                                                                       |    override def apply(emptybase: EmptyBase): Json = emptybase match {
+                                                                       |      case noprops: NoProps.type =>
+                                                                       |        NoProps.encoder(noprops)
+                                                                       |    }
+                                                                       |  }
+                                                                       |}""".stripMargin))
+
+        noProps.source.source.toString() should be(
+          s"""case object NoProps extends EmptyBase {
              |  import io.circe._
-             |  implicit def decodeAll(): Decoder[EmptyBase] = new Decoder[EmptyBase] {
-             |    override def apply(c: HCursor): Result[EmptyBase] = c.downField("type").as[String] match {
+             |  import io.circe.generic.semiauto._
+             |  import io.circe.Decoder.Result
+             |  implicit lazy val decoder: Decoder[NoProps.type] = new Decoder[NoProps.type] {
+             |    override def apply(c: HCursor): Result[NoProps.type] = c.downField("type").as[String] match {
              |      case Right("nope") =>
              |        Right(NoProps)
              |      case other =>
-             |        Left(DecodingFailure(s"unknown discriminator: $$other", c.history))
+             |        Left(DecodingFailure(s"unknown type: $$other", c.history))
              |    }
              |  }
-             |  implicit def encodeAll(): Encoder[EmptyBase] = new Encoder[EmptyBase] {
-             |    override def apply(emptybase: EmptyBase): Json = emptybase match {
-             |      case NoProps =>
-             |        Json.obj("type" -> Json.fromString("nope"))
-             |    }
-             |  }
-             |}""".stripMargin))
-
-        noProps.source.source.toString() should be(
-          s"""case object NoProps extends EmptyBase""".stripMargin
+             |  implicit lazy val encoder: Encoder[NoProps.type] = new Encoder[NoProps.type] { override def apply(a: NoProps.type): Json = Json.obj("type" -> Json.fromString("nope")) }
+             |}""".stripMargin
         )
 
         noSealedBase.source.source.toString() should be("trait NoSealedBase")
         noSealedBase.source.companion.map(_.toString()) should be(Some(s"""object NoSealedBase {
                                                                           |  import io.circe.Decoder.Result
                                                                           |  import io.circe._
-                                                                          |  implicit def decodeAll(implicit OtherSubDecoder: Decoder[OtherSub], MapLikeDecoder: Decoder[MapLike]): Decoder[NoSealedBase] = new Decoder[NoSealedBase] {
+                                                                          |  implicit lazy val decoder: Decoder[NoSealedBase] = new Decoder[NoSealedBase] {
                                                                           |    override def apply(c: HCursor): Result[NoSealedBase] = c.downField("type").as[String] match {
                                                                           |      case Right("other-sub") =>
-                                                                          |        OtherSubDecoder(c)
+                                                                          |        OtherSub.decoder(c)
                                                                           |      case Right("map-like") =>
-                                                                          |        MapLikeDecoder(c)
+                                                                          |        MapLike.decoder(c)
                                                                           |      case other =>
                                                                           |        Left(DecodingFailure(s"unknown discriminator: $$other", c.history))
                                                                           |    }
                                                                           |  }
-                                                                          |  implicit def encodeAll(implicit OtherSubEncoder: Encoder[OtherSub], MapLikeEncoder: Encoder[MapLike]): Encoder[NoSealedBase] = new Encoder[NoSealedBase] {
+                                                                          |  implicit lazy val encoder: Encoder[NoSealedBase] = new Encoder[NoSealedBase] {
                                                                           |    override def apply(nosealedbase: NoSealedBase): Json = nosealedbase match {
                                                                           |      case othersub: OtherSub =>
-                                                                          |        OtherSubEncoder(othersub).mapObject(_.add("type", Json.fromString("other-sub")))
+                                                                          |        OtherSub.encoder(othersub)
                                                                           |      case maplike: MapLike =>
-                                                                          |        MapLikeEncoder(maplike).mapObject(_.add("type", Json.fromString("map-like")))
+                                                                          |        MapLike.encoder(maplike)
                                                                           |    }
                                                                           |  }
                                                                           |}""".stripMargin))
@@ -131,14 +145,13 @@ class CirceJsonSupportSpec extends AnyFlatSpec with Matchers {
         )
 
         mapLike.source.companion.map(_.toString()) should be(Some(s"""object MapLike {
-             |  import io.circe.syntax._
-             |  import io.circe._
-             |  import io.circe.Decoder.Result
-             |  implicit lazy val json: Codec[MapLike] = new Codec[MapLike] {
-             |    override def apply(a: MapLike): Json = a.values.asJson
-             |    override def apply(c: HCursor): Result[MapLike] = c.as[Map[String, String]].map(MapLike.apply)
-             |  }
-             |}""".stripMargin))
+                                                                     |  import io.circe._
+                                                                     |  import io.circe.syntax._
+                                                                     |  import io.circe.generic.semiauto._
+                                                                     |  import io.circe.Decoder.Result
+                                                                     |  implicit lazy val decoder: Decoder[MapLike] = new Decoder[MapLike] { override def apply(c: HCursor): Result[MapLike] = c.as[Map[String, String]].map(MapLike.apply) }
+                                                                     |  implicit lazy val encoder: Encoder[MapLike] = new Encoder[MapLike] { override def apply(a: MapLike): Json = a.values.asJson }
+                                                                     |}""".stripMargin))
 
         someEnum.source.source.toString() should be(
           s"""sealed trait SomeEnum""".stripMargin
@@ -148,11 +161,11 @@ class CirceJsonSupportSpec extends AnyFlatSpec with Matchers {
                                                                       |  case object A extends SomeEnum
                                                                       |  case object B extends SomeEnum
                                                                       |  import io.circe._
-                                                                      |  implicit val encode: Encoder[SomeEnum] = Encoder[String].contramap({
+                                                                      |  implicit lazy val encoder: Encoder[SomeEnum] = Encoder[String].contramap({
                                                                       |    case A => "A"
                                                                       |    case B => "B"
                                                                       |  })
-                                                                      |  implicit val decode: Decoder[SomeEnum] = Decoder[String].emap({
+                                                                      |  implicit lazy val decoder: Decoder[SomeEnum] = Decoder[String].emap({
                                                                       |    case "A" =>
                                                                       |      Right(A)
                                                                       |    case "B" =>
@@ -181,33 +194,34 @@ class CirceJsonSupportSpec extends AnyFlatSpec with Matchers {
         )
         intermediateType.source.companion.map(_.toString()) should be(
           Some(s"""object IntermediateType {
-             |  import io.circe.Decoder.Result
-             |  import io.circe._
-             |  implicit def decodeAll(implicit GrandchildTypeDecoder: Decoder[GrandchildType]): Decoder[IntermediateType] = new Decoder[IntermediateType] {
-             |    override def apply(c: HCursor): Result[IntermediateType] = c.downField("type").as[String] match {
-             |      case Right("grandchild") =>
-             |        GrandchildTypeDecoder(c)
-             |      case other =>
-             |        Left(DecodingFailure(s"unknown discriminator: $$other", c.history))
-             |    }
-             |  }
-             |  implicit def encodeAll(implicit GrandchildTypeEncoder: Encoder[GrandchildType]): Encoder[IntermediateType] = new Encoder[IntermediateType] {
-             |    override def apply(intermediatetype: IntermediateType): Json = intermediatetype match {
-             |      case grandchildtype: GrandchildType =>
-             |        GrandchildTypeEncoder(grandchildtype).mapObject(_.add("type", Json.fromString("grandchild")))
-             |    }
-             |  }
-             |}""".stripMargin)
+                  |  import io.circe.Decoder.Result
+                  |  import io.circe._
+                  |  implicit lazy val decoder: Decoder[IntermediateType] = new Decoder[IntermediateType] {
+                  |    override def apply(c: HCursor): Result[IntermediateType] = c.downField("type").as[String] match {
+                  |      case Right("grandchild") =>
+                  |        GrandchildType.decoder(c)
+                  |      case other =>
+                  |        Left(DecodingFailure(s"unknown discriminator: $$other", c.history))
+                  |    }
+                  |  }
+                  |  implicit lazy val encoder: Encoder[IntermediateType] = new Encoder[IntermediateType] {
+                  |    override def apply(intermediatetype: IntermediateType): Json = intermediatetype match {
+                  |      case grandchildtype: GrandchildType =>
+                  |        GrandchildType.encoder(grandchildtype)
+                  |    }
+                  |  }
+                  |}""".stripMargin)
         )
 
         grandchildType.source.source.toString() should be(
           "final case class GrandchildType(id: String, foo: Option[String] = None, customTypeProp: scala.math.BigDecimal, customArrayTypeProp: Vector[scala.math.BigDecimal] = Vector.empty) extends IntermediateType"
         )
         grandchildType.source.companion.map(_.toString()) should be(Some(s"""object GrandchildType {
-             |  import io.circe._
-             |  import io.circe.generic.semiauto._
-             |  implicit lazy val json: Codec[GrandchildType] = deriveCodec[GrandchildType]
-             |}""".stripMargin))
+                                                                            |  import io.circe._
+                                                                            |  import io.circe.generic.semiauto._
+                                                                            |  implicit lazy val decoder: Decoder[GrandchildType] = deriveDecoder[GrandchildType]
+                                                                            |  implicit lazy val encoder: Encoder[GrandchildType] = deriveEncoder[GrandchildType].mapJsonObject(_.add("type", Json.fromString("grandchild")))
+                                                                            |}""".stripMargin))
     }
   }
 }

--- a/src/test/scala/scraml/SphereJsonSupportSpec.scala
+++ b/src/test/scala/scraml/SphereJsonSupportSpec.scala
@@ -20,7 +20,7 @@ class SphereJsonSupportSpec extends AnyFlatSpec with Matchers {
     val generated = ModelGenRunner.run(DefaultModelGen)(params).unsafeRunSync()
 
     generated.files match {
-      case noDiscBase :: _ :: _ :: baseType :: dataType :: emptyBase :: noProps :: _ :: _ :: _ :: _ :: _ :: Nil =>
+      case noDiscBase :: _ :: _ :: baseType :: _ :: _ :: dataType :: emptyBase :: noProps :: _ :: _ :: _ :: _ :: _ :: Nil =>
         noDiscBase.source.source.toString() should be("sealed trait NoDiscriminatorBase")
         noDiscBase.source.companion.map(_.toString()) should be(
           Some(s"""object NoDiscriminatorBase {


### PR DESCRIPTION
An alternative approach to https://github.com/commercetools/scraml/pull/6:

* always create `implicit lazy val encoder: Encoder` and `implicit lazy val decoder: Decoder` which will be reused in the super type encoders
* look up `discriminator` name in the parent types.
* create encoder/decoder for `case objects`
* add discriminator on encoding of `case class` 