### PR TITLE
Refined companion object generation

### DIFF
--- a/src/main/scala/scraml/libs/RefinedSupport.scala
+++ b/src/main/scala/scraml/libs/RefinedSupport.scala
@@ -579,7 +579,7 @@ object RefinedSupport extends LibrarySupport {
   }
 
   private def refinedTypeObject(
-      typeName : Type.Name,
+      typeName: Type.Name,
       originalType: Type,
       predicates: Type,
       optional: Boolean

--- a/src/main/scala/scraml/libs/RefinedSupport.scala
+++ b/src/main/scala/scraml/libs/RefinedSupport.scala
@@ -402,7 +402,8 @@ object RefinedSupport extends LibrarySupport {
             itemPredicates ++ List[Stat](
               q"""
                 type $typeName = Option[Refined[$originalType,${predicates(prop)}]]
-                """
+                """,
+              refinedTypeObject(typeName, originalType, predicates(prop), true)
             )
 
           case RefinedPropertyType(typeName, Some(itemName), _) =>
@@ -418,18 +419,23 @@ object RefinedSupport extends LibrarySupport {
             }
 
             itemPredicates ++ List[Stat](
-              q"type $typeName = Refined[$originalType,${predicates(prop)}]"
+              q"type $typeName = Refined[$originalType,${predicates(prop)}]",
+              refinedTypeObject(typeName, originalType, predicates(prop), false)
             )
 
           case RefinedPropertyType(typeName, None, optional) if optional =>
             List[Stat](
               q"""
                 type $typeName = Option[Refined[$originalType,${predicates(prop)}]]
-                """
+                """,
+              refinedTypeObject(typeName, originalType, predicates(prop), true)
             )
 
           case RefinedPropertyType(typeName, None, _) =>
-            List[Stat](q"type $typeName = Refined[$originalType,${predicates(prop)}]")
+            List[Stat](
+              q"type $typeName = Refined[$originalType,${predicates(prop)}]",
+              refinedTypeObject(typeName, originalType, predicates(prop), false)
+            )
 
           case _ =>
             List.empty[Stat]
@@ -570,5 +576,67 @@ object RefinedSupport extends LibrarySupport {
       q"val dummy: And[$lhs, ${reduce(head, tail)}]".decltpe
     case Nil =>
       throw new RuntimeException("logic error: unable to reduce an empty list")
+  }
+
+  private def refinedTypeObject(
+      typeName : Type.Name,
+      originalType: Type,
+      predicates: Type,
+      optional: Boolean
+  ): Defn.Object = {
+    /// These "companion-like" object definitions are inspired by the refined
+    /// `RefTypeOps` class.
+    if (optional)
+      q"""
+      object ${Term.Name(typeName.value)} {
+        import eu.timepit.refined.api._
+
+        type ResultType = Refined[$originalType,$predicates]
+
+        private val rt = RefinedType.apply[ResultType]
+
+        def apply(candidate: $originalType): Either[IllegalArgumentException, Option[ResultType]] =
+          from(Option(candidate))
+
+        def apply(candidate: Option[$originalType]): Either[IllegalArgumentException, Option[ResultType]] =
+          from(candidate)
+
+        def from(candidate: Option[$originalType]): Either[IllegalArgumentException, Option[ResultType]] =
+          candidate match {
+            case Some(value) =>
+              rt.refine(value).map(Some(_)).left.map(msg => new IllegalArgumentException(msg))
+            case None =>
+              Right(None)
+          }
+
+        def unapply(candidate: Option[$originalType]): Option[ResultType] =
+          from(candidate).fold(_ => None, a => a)
+
+        def unsafeFrom(candidate: Option[$originalType]): Option[ResultType] =
+          candidate.map(rt.unsafeRefine)
+      }
+     """
+    else
+      q"""
+      object ${Term.Name(typeName.value)} {
+        import eu.timepit.refined.api._
+
+        type ResultType = Refined[$originalType,$predicates]
+
+        private val rt = RefinedType.apply[ResultType]
+
+        def apply(candidate: $originalType): Either[IllegalArgumentException, ResultType] =
+          from(candidate)
+
+        def from(candidate: $originalType): Either[IllegalArgumentException, ResultType] =
+          rt.refine(candidate).left.map(msg => new IllegalArgumentException(msg))
+
+        def unapply(candidate: $originalType): Option[ResultType] =
+          from(candidate).toOption
+
+        def unsafeFrom(candidate: $originalType): ResultType =
+          rt.unsafeRefine(candidate)
+      }
+     """
   }
 }

--- a/src/test/scala/scraml/libs/RefinedSupportSpec.scala
+++ b/src/test/scala/scraml/libs/RefinedSupportSpec.scala
@@ -50,15 +50,96 @@ class RefinedSupportSpec extends AnyWordSpec with Diagrams {
             |  import shapeless.Witness
             |  import io.circe.refined._
             |  type IdType = Refined[String, And[MinSize[Witness.`1`.T], And[MaxSize[Witness.`10`.T], MatchesRegex[Witness.`"^[A-z0-9-.]+$"`.T]]]]
+            |  object IdType {
+            |    import eu.timepit.refined.api._
+            |    type ResultType = Refined[String, And[MinSize[Witness.`1`.T], And[MaxSize[Witness.`10`.T], MatchesRegex[Witness.`"^[A-z0-9-.]+$"`.T]]]]
+            |    private val rt = RefinedType.apply[ResultType]
+            |    def apply(candidate: String): Either[IllegalArgumentException, ResultType] = from(candidate)
+            |    def from(candidate: String): Either[IllegalArgumentException, ResultType] = rt.refine(candidate).left.map(msg => new IllegalArgumentException(msg))
+            |    def unapply(candidate: String): Option[ResultType] = from(candidate).toOption
+            |    def unsafeFrom(candidate: String): ResultType = rt.unsafeRefine(candidate)
+            |  }
             |  type OptionalCustomArrayTypePropItemPredicate = GreaterEqual[Witness.`0.0`.T]
             |  type OptionalCustomArrayTypePropType = Option[Refined[Set[scala.math.BigDecimal], And[MinSize[Witness.`1`.T], And[MaxSize[Witness.`100`.T], Forall[OptionalCustomArrayTypePropItemPredicate]]]]]
+            |  object OptionalCustomArrayTypePropType {
+            |    import eu.timepit.refined.api._
+            |    type ResultType = Refined[Set[scala.math.BigDecimal], And[MinSize[Witness.`1`.T], And[MaxSize[Witness.`100`.T], Forall[OptionalCustomArrayTypePropItemPredicate]]]]
+            |    private val rt = RefinedType.apply[ResultType]
+            |    def apply(candidate: Set[scala.math.BigDecimal]): Either[IllegalArgumentException, Option[ResultType]] = from(Option(candidate))
+            |    def apply(candidate: Option[Set[scala.math.BigDecimal]]): Either[IllegalArgumentException, Option[ResultType]] = from(candidate)
+            |    def from(candidate: Option[Set[scala.math.BigDecimal]]): Either[IllegalArgumentException, Option[ResultType]] = candidate match {
+            |      case Some(value) =>
+            |        rt.refine(value).map(Some(_)).left.map(msg => new IllegalArgumentException(msg))
+            |      case None =>
+            |        Right(None)
+            |    }
+            |    def unapply(candidate: Option[Set[scala.math.BigDecimal]]): Option[ResultType] = from(candidate).fold(_ => None, a => a)
+            |    def unsafeFrom(candidate: Option[Set[scala.math.BigDecimal]]): Option[ResultType] = candidate.map(rt.unsafeRefine)
+            |  }
             |  type BarType = Option[Refined[String, MatchesRegex[Witness.`"^[A-z]+$"`.T]]]
+            |  object BarType {
+            |    import eu.timepit.refined.api._
+            |    type ResultType = Refined[String, MatchesRegex[Witness.`"^[A-z]+$"`.T]]
+            |    private val rt = RefinedType.apply[ResultType]
+            |    def apply(candidate: String): Either[IllegalArgumentException, Option[ResultType]] = from(Option(candidate))
+            |    def apply(candidate: Option[String]): Either[IllegalArgumentException, Option[ResultType]] = from(candidate)
+            |    def from(candidate: Option[String]): Either[IllegalArgumentException, Option[ResultType]] = candidate match {
+            |      case Some(value) =>
+            |        rt.refine(value).map(Some(_)).left.map(msg => new IllegalArgumentException(msg))
+            |      case None =>
+            |        Right(None)
+            |    }
+            |    def unapply(candidate: Option[String]): Option[ResultType] = from(candidate).fold(_ => None, a => a)
+            |    def unsafeFrom(candidate: Option[String]): Option[ResultType] = candidate.map(rt.unsafeRefine)
+            |  }
             |  type NumberPropType = Refined[Float, Interval.Closed[Witness.`0`.T, Witness.`99.99999`.T]]
+            |  object NumberPropType {
+            |    import eu.timepit.refined.api._
+            |    type ResultType = Refined[Float, Interval.Closed[Witness.`0`.T, Witness.`99.99999`.T]]
+            |    private val rt = RefinedType.apply[ResultType]
+            |    def apply(candidate: Float): Either[IllegalArgumentException, ResultType] = from(candidate)
+            |    def from(candidate: Float): Either[IllegalArgumentException, ResultType] = rt.refine(candidate).left.map(msg => new IllegalArgumentException(msg))
+            |    def unapply(candidate: Float): Option[ResultType] = from(candidate).toOption
+            |    def unsafeFrom(candidate: Float): ResultType = rt.unsafeRefine(candidate)
+            |  }
             |  type CustomNumberPropType = Refined[scala.math.BigDecimal, LessEqual[Witness.`99.99999`.T]]
+            |  object CustomNumberPropType {
+            |    import eu.timepit.refined.api._
+            |    type ResultType = Refined[scala.math.BigDecimal, LessEqual[Witness.`99.99999`.T]]
+            |    private val rt = RefinedType.apply[ResultType]
+            |    def apply(candidate: scala.math.BigDecimal): Either[IllegalArgumentException, ResultType] = from(candidate)
+            |    def from(candidate: scala.math.BigDecimal): Either[IllegalArgumentException, ResultType] = rt.refine(candidate).left.map(msg => new IllegalArgumentException(msg))
+            |    def unapply(candidate: scala.math.BigDecimal): Option[ResultType] = from(candidate).toOption
+            |    def unsafeFrom(candidate: scala.math.BigDecimal): ResultType = rt.unsafeRefine(candidate)
+            |  }
             |  type CustomArrayTypePropItemPredicate = Interval.Closed[Witness.`1.23`.T, Witness.`4.56`.T]
             |  type CustomArrayTypePropType = Refined[Vector[scala.math.BigDecimal], And[MaxSize[Witness.`100`.T], Forall[CustomArrayTypePropItemPredicate]]]
+            |  object CustomArrayTypePropType {
+            |    import eu.timepit.refined.api._
+            |    type ResultType = Refined[Vector[scala.math.BigDecimal], And[MaxSize[Witness.`100`.T], Forall[CustomArrayTypePropItemPredicate]]]
+            |    private val rt = RefinedType.apply[ResultType]
+            |    def apply(candidate: Vector[scala.math.BigDecimal]): Either[IllegalArgumentException, ResultType] = from(candidate)
+            |    def from(candidate: Vector[scala.math.BigDecimal]): Either[IllegalArgumentException, ResultType] = rt.refine(candidate).left.map(msg => new IllegalArgumentException(msg))
+            |    def unapply(candidate: Vector[scala.math.BigDecimal]): Option[ResultType] = from(candidate).toOption
+            |    def unsafeFrom(candidate: Vector[scala.math.BigDecimal]): ResultType = rt.unsafeRefine(candidate)
+            |  }
             |  type OptionalStringArrayItemPredicate = And[MinSize[Witness.`2`.T], And[MaxSize[Witness.`42`.T], MatchesRegex[Witness.`"^[A-z0-9]+$"`.T]]]
             |  type OptionalStringArrayType = Option[Refined[scala.collection.immutable.List[String], Forall[OptionalStringArrayItemPredicate]]]
+            |  object OptionalStringArrayType {
+            |    import eu.timepit.refined.api._
+            |    type ResultType = Refined[scala.collection.immutable.List[String], Forall[OptionalStringArrayItemPredicate]]
+            |    private val rt = RefinedType.apply[ResultType]
+            |    def apply(candidate: scala.collection.immutable.List[String]): Either[IllegalArgumentException, Option[ResultType]] = from(Option(candidate))
+            |    def apply(candidate: Option[scala.collection.immutable.List[String]]): Either[IllegalArgumentException, Option[ResultType]] = from(candidate)
+            |    def from(candidate: Option[scala.collection.immutable.List[String]]): Either[IllegalArgumentException, Option[ResultType]] = candidate match {
+            |      case Some(value) =>
+            |        rt.refine(value).map(Some(_)).left.map(msg => new IllegalArgumentException(msg))
+            |      case None =>
+            |        Right(None)
+            |    }
+            |    def unapply(candidate: Option[scala.collection.immutable.List[String]]): Option[ResultType] = from(candidate).fold(_ => None, a => a)
+            |    def unsafeFrom(candidate: Option[scala.collection.immutable.List[String]]): Option[ResultType] = candidate.map(rt.unsafeRefine)
+            |  }
             |  import io.circe._
             |  import io.circe.generic.semiauto._
             |  implicit lazy val decoder: Decoder[DataType] = deriveDecoder[DataType]


### PR DESCRIPTION
To help facilitate programmatic creation of refined properties, `scraml` now generates `object` types which have methods very similar to those found in [RefinedTypeOps](https://github.com/fthomas/refined/blob/master/modules/core/shared/src/main/scala-3.0-/eu/timepit/refined/api/RefinedTypeOps.scala). 