### PR TITLE
Add multiple root document support

### DIFF
--- a/src/main/paradox/setup.md
+++ b/src/main/paradox/setup.md
@@ -12,6 +12,22 @@
 
 ## Configure your build
 
+For projects which have one [RAML API specification](https://raml.org/) root document, each SCRAML setting can be specified individually, with `ramlFile` being the only required setting for `runScraml`.
+
 `build.sbt`:
 
 @@snip [build.sbt](../../../src/sbt-test/sbt-scraml/simple/build.sbt) {}
+
+
+Projects which have two or more [RAML API specification](https://raml.org/) root documents must use the `ramlDefinitions` setting and **not** `ramlFile`.  If both are set, `ramlFile` will take precedence and `ramlDefinitions` will be ignored.
+
+`build.sbt`:
+
+@@snip [build.sbt](../../../src/sbt-test/sbt-scraml/two-specifications/build.sbt) {}
+
+Notes:
+
+* Each `basePackage` **must** be unique across all `scraml.ModelDefinition`s.
+* The `defaultTypes` can be set globally and will be used for each `scraml.ModelDefinition` which has a `defaultTypes` with all default values.
+* The `libraryDefinitions` can be set globally and will be used for each `scraml.ModelDefinition` which has an empty `Set`.
+

--- a/src/main/scala/scraml/DefaultModelGen.scala
+++ b/src/main/scala/scraml/DefaultModelGen.scala
@@ -158,7 +158,9 @@ object DefaultModelGen extends ModelGen {
       stringType: StringType,
       params: ModelGenParams
   ): IO[GeneratedTypeSource] = for {
-    packageName <- IO.fromOption(getPackageName(stringType))(
+    packageName <- IO.fromOption(
+      getPackageName(stringType).orElse(params.defaultPackageAnnotation)
+    )(
       new IllegalStateException("enum type should have package name")
     )
     enumInstances = stringType.getEnum.asScala.map { instance =>
@@ -194,7 +196,9 @@ object DefaultModelGen extends ModelGen {
       api: ApiContext
   ): IO[GeneratedTypeSource] =
     for {
-      packageName <- IO.fromOption(getPackageName(objectType))(
+      packageName <- IO.fromOption(
+        getPackageName(objectType).orElse(params.defaultPackageAnnotation)
+      )(
         new IllegalStateException("object type should have package name")
       )
       apiBaseType = Option(objectType.asInstanceOf[AnyType].getType)

--- a/src/main/scala/scraml/ModelDefinition.scala
+++ b/src/main/scala/scraml/ModelDefinition.scala
@@ -1,0 +1,39 @@
+package scraml
+
+import java.io.File
+
+import sbt.internal.util.ManagedLogger
+
+final case class ModelDefinition(
+    raml: File,
+    basePackage: String,
+    defaultTypes: DefaultTypes = DefaultTypes(),
+    librarySupport: Set[LibrarySupport] = Set.empty,
+    defaultPackageAnnotation: Option[String] = None,
+    formatConfig: Option[File] = None,
+    generateDateCreated: Boolean = false
+) {
+  def toModelGenParams(
+      targetDir: File,
+      compilerVersion: Option[(Long, Long)],
+      logger: ManagedLogger
+  ): ModelGenParams =
+    ModelGenParams(
+      raml = raml,
+      targetDir = targetDir,
+      basePackage = basePackage,
+      defaultTypes = defaultTypes,
+      librarySupport = librarySupport,
+      scalaVersion = compilerVersion,
+      formatConfig = formatConfig,
+      generateDateCreated = generateDateCreated,
+      logger = Some(logger),
+      defaultPackageAnnotation = defaultPackageAnnotation.map(_.toLowerCase())
+    )
+
+  def useDefaultLibrarySupport(default: Set[LibrarySupport]): ModelDefinition =
+    if (librarySupport.isEmpty)
+      copy(librarySupport = default)
+    else
+      this
+}

--- a/src/main/scala/scraml/ModelDefinition.scala
+++ b/src/main/scala/scraml/ModelDefinition.scala
@@ -15,25 +15,34 @@ final case class ModelDefinition(
 ) {
   def toModelGenParams(
       targetDir: File,
+      fallbackDefaultTypes: DefaultTypes,
+      fallbackLibrarySupport: Set[LibrarySupport],
       compilerVersion: Option[(Long, Long)],
       logger: ManagedLogger
-  ): ModelGenParams =
+  ): ModelGenParams = {
+    val librariesToEnable =
+      if (librarySupport.isEmpty)
+        fallbackLibrarySupport
+      else
+        librarySupport
+
+    val typesToUse =
+      if (defaultTypes == DefaultTypes())
+        fallbackDefaultTypes
+      else
+        defaultTypes
+
     ModelGenParams(
       raml = raml,
       targetDir = targetDir,
       basePackage = basePackage,
-      defaultTypes = defaultTypes,
-      librarySupport = librarySupport,
+      defaultTypes = typesToUse,
+      librarySupport = librariesToEnable,
       scalaVersion = compilerVersion,
       formatConfig = formatConfig,
       generateDateCreated = generateDateCreated,
       logger = Some(logger),
       defaultPackageAnnotation = defaultPackageAnnotation.map(_.toLowerCase())
     )
-
-  def useDefaultLibrarySupport(default: Set[LibrarySupport]): ModelDefinition =
-    if (librarySupport.isEmpty)
-      copy(librarySupport = default)
-    else
-      this
+  }
 }

--- a/src/main/scala/scraml/ModelGen.scala
+++ b/src/main/scala/scraml/ModelGen.scala
@@ -44,7 +44,8 @@ final case class ModelGenParams(
     scalaVersion: Option[(Long, Long)] = Some((2, 12)),
     formatConfig: Option[File] = None,
     generateDateCreated: Boolean = false,
-    logger: Option[ManagedLogger] = None
+    logger: Option[ManagedLogger] = None,
+    defaultPackageAnnotation: Option[String] = None
 ) {
   lazy val allLibraries: List[LibrarySupport] = librarySupport.toList.sorted
 }

--- a/src/main/scala/scraml/ScramlPlugin.scala
+++ b/src/main/scala/scraml/ScramlPlugin.scala
@@ -93,7 +93,7 @@ object ScramlPlugin extends AutoPlugin {
     definitions: Seq[ModelDefinition]
   ): Seq[ModelDefinition] = {
     val packages = definitions.map(_.basePackage).sorted
-    val duplicates = packages.grouped(2)
+    val duplicates = packages.combinations(2)
       .toList
       .filter {
         case Seq(a, b) if a == b =>

--- a/src/main/scala/scraml/ScramlPlugin.scala
+++ b/src/main/scala/scraml/ScramlPlugin.scala
@@ -3,12 +3,16 @@ package scraml
 import cats.effect.unsafe.implicits.global
 import sbt._
 import sbt.Keys._
+import sbt.internal.util.ManagedLogger
 
 object ScramlPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   object autoImport {
     val ramlFile = settingKey[Option[File]]("RAML file to be used by the sbt-scraml plugin")
+    val ramlDefinitions = settingKey[Seq[ModelDefinition]](
+      "RAML definitions to be used for by the sbt-scraml plugin"
+    )
     val scramlTargetDir = settingKey[Option[File]](
       "target dir to use for generation, otherwise 'Compile / sourceManaged' is used"
     )
@@ -24,6 +28,7 @@ object ScramlPlugin extends AutoPlugin {
   import autoImport._
   override lazy val globalSettings: Seq[Setting[_]] = Seq(
     ramlFile        := None,
+    ramlDefinitions := Seq.empty,
     basePackageName := "scraml",
     defaultTypes    := DefaultTypes(),
     librarySupport  := Set.empty,
@@ -38,40 +43,71 @@ object ScramlPlugin extends AutoPlugin {
   override lazy val projectSettings: Seq[Setting[_]] = Seq(
     runScraml := {
       val targetDir: File = scramlTargetDir.value.getOrElse((Compile / sourceManaged).value)
+      val s               = streams.value
+      val definitions     = detectDuplicateBasePackages(s.log) {
+        ramlFile.value
+          .map {
+            raml =>
+              ModelDefinition(
+                raml,
+                basePackageName.value,
+                defaultTypes.value,
+                librarySupport.value,
+                None,
+                formatConfig.value
+              ) :: Nil
+          }
+          .getOrElse(ramlDefinitions.value)
+          .map(_.useDefaultLibrarySupport(librarySupport.value))
+      }
+
       // adapted from https://stackoverflow.com/questions/33897874/sbt-sourcegenerators-task-execute-only-if-a-file-changes
       val cachedGeneration = FileFunction.cached(
         streams.value.cacheDirectory / "scraml"
       ) { (_: Set[File]) =>
-        ramlFile.value
-          .map { file =>
-            val s = streams.value
-            val params = ModelGenParams(
-              file,
-              targetDir,
-              basePackageName.value,
-              defaultTypes.value,
-              librarySupport.value,
-              CrossVersion.partialVersion(scalaVersion.value),
-              formatConfig.value,
-              logger = Option(s.log)
-            )
+        definitions.flatMap { definition =>
+          val params = definition.toModelGenParams(
+            targetDir,
+            CrossVersion.partialVersion(scalaVersion.value),
+            s.log
+          )
 
-            val generated = ModelGenRunner.run(DefaultModelGen)(params).unsafeRunSync()
+          val generated = ModelGenRunner.run(DefaultModelGen)(params).unsafeRunSync()
 
-            s.log.info(s"generated API model for $file in $targetDir")
-            s.log.debug(generated.toString)
-            generated.files.map(_.file)
-          }
-          .getOrElse(List.empty)
-          .toSet
+          s.log.info(s"generated API model for ${definition.raml} in $targetDir")
+          s.log.debug(generated.toString)
+          generated.files.map(_.file)
+        }.toSet
       }
 
-      ramlFile.value match {
-        case Some(apiFile) =>
-          val inputFiles = FileUtil.findFiles(apiFile.getParentFile).map(_.toFile).toSet
-          cachedGeneration(inputFiles).toSeq
-        case None => Seq.empty
-      }
+      val allRamls = definitions
+        .flatMap(definition => FileUtil.findFiles(definition.raml.getParentFile))
+        .map(_.toFile)
+        .toSet
+
+      cachedGeneration(allRamls).toSeq
     }
   )
+
+  private def detectDuplicateBasePackages(logger: ManagedLogger)(
+    definitions: Seq[ModelDefinition]
+  ): Seq[ModelDefinition] = {
+    val packages = definitions.map(_.basePackage).sorted
+    val duplicates = packages.grouped(2)
+      .toList
+      .filter {
+        case Seq(a, b) if a == b =>
+          logger.error(s"duplicate base packages detected: '$a' and '$b''")
+          true
+        case _ =>
+          false
+      }
+
+    duplicates.headOption.foreach {
+      case Seq(a, b) =>
+        throw new IllegalArgumentException(s"duplicate base packages detected: '$a' and '$b''")
+    }
+
+    definitions
+  }
 }

--- a/src/sbt-test/sbt-scraml/refined/build.sbt
+++ b/src/sbt-test/sbt-scraml/refined/build.sbt
@@ -18,7 +18,7 @@ lazy val root = (project in file("."))
       scraml.libs.RefinedSupport
     ),
     Compile / sourceGenerators += runScraml,
-	libraryDependencies += "com.chuusai" %% "shapeless" % "2.3.7",
+    libraryDependencies += "com.chuusai" %% "shapeless" % "2.3.7",
     libraryDependencies ++= Seq(
       "eu.timepit" %% "refined",
       "eu.timepit" %% "refined-cats"
@@ -30,3 +30,4 @@ lazy val root = (project in file("."))
         "io.circe" %% "circe-refined"
     ).map(_ % circeVersion)
   )
+

--- a/src/sbt-test/sbt-scraml/two-specifications/api/annotations.raml
+++ b/src/sbt-test/sbt-scraml/two-specifications/api/annotations.raml
@@ -1,0 +1,19 @@
+# the package will be used as the file name, currently no actual package structure is generated
+package:
+  type: string
+  allowedTargets: TypeDeclaration
+# allows to specify a url for documentation purposes, not reflected in the code currently
+docs-uri:
+  type: string
+# allows to override the type used with a full qualified name of a scala type
+scala-type:
+  type: string
+# allows to override the default type for a collection
+scala-array-type:
+  type: string
+# allows to specify an additional supertype like a traited
+scala-extends:
+  type: string
+# allows to control on a granular level if JSON support is enabled for the annotated type
+scala-derive-json:
+  type: boolean

--- a/src/sbt-test/sbt-scraml/two-specifications/api/datatype.raml
+++ b/src/sbt-test/sbt-scraml/two-specifications/api/datatype.raml
@@ -1,0 +1,18 @@
+#%RAML 1.0 DataType
+(package): DataTypes
+(docs-uri): "https://example.org/data-type"
+displayName: DataType
+(scala-derive-json): true
+properties:
+  foo?:
+    type: string
+  customTypeProp:
+    (scala-type): "scala.math.BigDecimal"
+    type: number
+  customArrayTypeProp:
+    (scala-array-type): "Vector"
+    type: array
+    (scala-type): "scala.math.BigDecimal"
+    items:
+      type: object
+

--- a/src/sbt-test/sbt-scraml/two-specifications/api/inline-types.raml
+++ b/src/sbt-test/sbt-scraml/two-specifications/api/inline-types.raml
@@ -1,0 +1,21 @@
+#%RAML 1.0
+title: Hello world # required title
+# taken from https://github.com/raml-org/raml-spec
+annotationTypes: !include annotations.raml
+# this test checks for inline type definition support via 'ramlDefinitions'
+types:
+  DataType:
+    properties:
+      text: string
+      when: datetime
+
+/greeting: # optional resource
+  get: # HTTP method declaration
+    queryParameters:
+      name?:
+        type: string
+    responses: # declare a response
+      200: # HTTP status code
+        body: # declare content of response
+          application/json: # media type
+            type: DataType

--- a/src/sbt-test/sbt-scraml/two-specifications/api/simple.raml
+++ b/src/sbt-test/sbt-scraml/two-specifications/api/simple.raml
@@ -1,0 +1,17 @@
+#%RAML 1.0
+title: Hello world # required title
+# taken from https://github.com/raml-org/raml-spec
+annotationTypes: !include annotations.raml
+# this is not optional, the file included here must follow the format shown 'types.raml'
+types: !include types.raml
+
+/greeting: # optional resource
+  get: # HTTP method declaration
+    queryParameters:
+      name?:
+        type: string
+    responses: # declare a response
+      200: # HTTP status code
+        body: # declare content of response
+          application/json: # media type
+            type: DataType

--- a/src/sbt-test/sbt-scraml/two-specifications/api/types.raml
+++ b/src/sbt-test/sbt-scraml/two-specifications/api/types.raml
@@ -1,0 +1,1 @@
+DataType: !include datatype.raml

--- a/src/sbt-test/sbt-scraml/two-specifications/build.sbt
+++ b/src/sbt-test/sbt-scraml/two-specifications/build.sbt
@@ -12,15 +12,22 @@ lazy val root = (project in file("."))
       scraml.ModelDefinition(
         raml = file("api/inline-types.raml"),
         basePackage = "scraml.inline",
-        defaultTypes = scraml.DefaultTypes(),
+        // Explicitly override the default Scala types for this definition.
+        defaultTypes = scraml.DefaultTypes(
+          float = "Double",
+          number = "scala.math.BigDecimal"
+        ),
+        // Use DataTypes for RAML type definitions which do not have a
+        // (package) annotation.
         defaultPackageAnnotation = Some("DataTypes"),
+        // Explicitly override the global librarySupport setting.
+        librarySupport = Set(scraml.libs.CatsShowSupport),
         formatConfig = None,
         generateDateCreated = true
         ),
       scraml.ModelDefinition(
         raml = file("api/simple.raml"),
         basePackage = "scraml.simple",
-        defaultTypes = scraml.DefaultTypes(),
         defaultPackageAnnotation = None,
         formatConfig = None,
         generateDateCreated = true
@@ -29,7 +36,7 @@ lazy val root = (project in file("."))
     Compile / sourceGenerators += runScraml,
     libraryDependencies ++= Seq(
       "org.typelevel" %% "cats-core" % "2.7.0",
-      "dev.optics" %% "monocle-core" % "3.0.0",
+      "dev.optics" %% "monocle-core" % "3.1.0"
     )
   )
 

--- a/src/sbt-test/sbt-scraml/two-specifications/build.sbt
+++ b/src/sbt-test/sbt-scraml/two-specifications/build.sbt
@@ -1,0 +1,35 @@
+lazy val root = (project in file("."))
+  .settings(
+    scalaVersion := "2.13.6",
+    name := "scraml-two-specifications",
+    version := "0.1",
+    librarySupport := Set(
+      scraml.libs.CatsEqSupport,
+      scraml.libs.CatsShowSupport,
+      scraml.libs.MonocleOpticsSupport
+    ),
+    ramlDefinitions := Seq(
+      scraml.ModelDefinition(
+        raml = file("api/inline-types.raml"),
+        basePackage = "scraml.inline",
+        defaultTypes = scraml.DefaultTypes(),
+        defaultPackageAnnotation = Some("DataTypes"),
+        formatConfig = None,
+        generateDateCreated = true
+        ),
+      scraml.ModelDefinition(
+        raml = file("api/simple.raml"),
+        basePackage = "scraml.simple",
+        defaultTypes = scraml.DefaultTypes(),
+        defaultPackageAnnotation = None,
+        formatConfig = None,
+        generateDateCreated = true
+        ),
+      ),
+    Compile / sourceGenerators += runScraml,
+    libraryDependencies ++= Seq(
+      "org.typelevel" %% "cats-core" % "2.7.0",
+      "dev.optics" %% "monocle-core" % "3.0.0",
+    )
+  )
+

--- a/src/sbt-test/sbt-scraml/two-specifications/project/plugins.sbt
+++ b/src/sbt-test/sbt-scraml/two-specifications/project/plugins.sbt
@@ -1,0 +1,5 @@
+sys.props.get("plugin.version") match {
+  case Some(x) => addSbtPlugin("com.commercetools" % "sbt-scraml" % x)
+  case _ => sys.error("""|The system property 'plugin.version' is not defined.
+                         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+}

--- a/src/sbt-test/sbt-scraml/two-specifications/test
+++ b/src/sbt-test/sbt-scraml/two-specifications/test
@@ -1,0 +1,6 @@
+> compile
+# make sure the expected output is present
+$ exists target/scala-2.13/src_managed/main/scraml/inline/datatypes.scala
+$ exists target/scala-2.13/src_managed/main/scraml/inline/package.scala
+$ exists target/scala-2.13/src_managed/main/scraml/simple/datatypes.scala
+$ exists target/scala-2.13/src_managed/main/scraml/simple/package.scala


### PR DESCRIPTION
This adds the ability to run scraml with multiple
root documents, each having the generated Scala
code in a separate package.