### PR TITLE
(tapir): support enum types in string contexts

### DIFF
--- a/src/test/scala/scraml/libs/RefinedSupportSpec.scala
+++ b/src/test/scala/scraml/libs/RefinedSupportSpec.scala
@@ -7,15 +7,7 @@ import org.scalatest.diagrams.Diagrams
 import org.scalatest.wordspec.AnyWordSpec
 import scraml.{DefaultModelGen, DefaultTypes, ModelGenParams, ModelGenRunner}
 
-class RefinedSupportSpec extends AnyWordSpec with Diagrams {
-  implicit class StripTrailingSpaces(private val content: String) {
-    def stripTrailingSpaces: String =
-      content
-        .split('\n')
-        .map(_.replaceFirst(" +$", ""))
-        .mkString("\n")
-  }
-
+class RefinedSupportSpec extends AnyWordSpec with Diagrams with SourceCodeFormatting {
   "RefinedSupport" must {
     "modify case class refined property types" in {
       val params = ModelGenParams(

--- a/src/test/scala/scraml/libs/SourceCodeFormatting.scala
+++ b/src/test/scala/scraml/libs/SourceCodeFormatting.scala
@@ -1,0 +1,15 @@
+package scraml.libs
+
+import org.scalatest.Suite
+
+trait SourceCodeFormatting {
+  this: Suite =>
+
+  implicit class StripTrailingSpaces(private val content: String) {
+    def stripTrailingSpaces: String =
+      content
+        .split('\n')
+        .map(_.replaceFirst(" +$", ""))
+        .mkString("\n")
+  }
+}


### PR DESCRIPTION
RAML enum types can now be used in tapir methods which
are for string contexts, such as the Endpoint input and
output methods related to URI's.