### PR TITLE
Add support for RAML default facet

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.6.1
+sbt.version = 1.6.2

--- a/src/main/scala/scraml/ModelGen.scala
+++ b/src/main/scala/scraml/ModelGen.scala
@@ -7,7 +7,7 @@ import scraml.MetaUtil.{packageTerm, typeFromName}
 import scraml.RMFUtil.{getAnnotation, getPackageName}
 import java.io.File
 import scala.collection.immutable.TreeSet
-import scala.meta.{Decl, Defn, Member, Pkg, Stat, Term, Type}
+import scala.meta._
 import scala.reflect.ClassTag
 
 import sbt.internal.util.ManagedLogger
@@ -220,6 +220,8 @@ trait LibrarySupport {
       anyType match {
         case at: ArrayType =>
           hasFacets(at)
+        case it: IntegerType =>
+          hasFacets(it)
         case nt: NumberType =>
           hasFacets(nt)
         case st: StringType =>
@@ -233,6 +235,10 @@ trait LibrarySupport {
         (at.getMinItems ne null) ||
         (at.getUniqueItems ne null) ||
         hasItemFacets(at)
+
+    final def hasFacets(it: IntegerType): Boolean =
+      (it.getMaximum ne null) ||
+        (it.getMinimum ne null)
 
     final def hasFacets(nt: NumberType): Boolean =
       (nt.getMaximum ne null) ||
@@ -383,8 +389,22 @@ object ModelGen {
   private case class TypeRefDetails(
       baseType: Type,
       packageName: Option[String] = None,
-      defaultValue: Option[Term] = None
-  )
+      defaultValue: Option[Term] = None,
+      isCollection: Boolean = false
+  ) {
+    def addDefaultValue[A <: AnyType](property: A): TypeRefDetails =
+      Option(property.getDefault).fold(this) { instance =>
+        property match {
+          case _: StringType =>
+            val raw = instance.getValue.toString
+
+            copy(defaultValue = Option(Lit.String(raw)))
+
+          case _ =>
+            copy(defaultValue = instance.getValue.toString.parse[Term].toOption)
+        }
+      }
+  }
 
   def scalaTypeRef(
       apiType: AnyType,
@@ -401,37 +421,39 @@ object ModelGen {
 
     lazy val mappedType = apiType match {
       case boolean: BooleanType =>
-        overrideTypeOr(boolean, context.params.defaultTypes.boolean)
+        overrideTypeOr(boolean, context.params.defaultTypes.boolean).addDefaultValue(boolean)
       case integer: IntegerType =>
-        overrideTypeOr(integer, context.params.defaultTypes.integer)
+        overrideTypeOr(integer, context.params.defaultTypes.integer).addDefaultValue(integer)
       case number: NumberType =>
-        overrideTypeOr(number, numberTypeString(number))
+        overrideTypeOr(number, numberTypeString(number)).addDefaultValue(number)
       // only use enum type names on top-level defined enums
       // we would need to generate types for property types otherwise
-      case _: StringType if apiType.eContainer().eClass().getName == "Property" =>
-        TypeRefDetails(Type.Name("String"))
+      case string: StringType if apiType.eContainer().eClass().getName == "Property" =>
+        TypeRefDetails(Type.Name("String")).addDefaultValue(string)
       case stringEnum: StringType
           if Option(stringEnum.getEnum).forall(!_.isEmpty) && stringEnum.getName != "string" =>
         TypeRefDetails(Type.Name(stringEnum.getName))
       case string: StringType =>
-        overrideTypeOr(string, context.params.defaultTypes.string)
+        overrideTypeOr(string, context.params.defaultTypes.string).addDefaultValue(string)
       case array: ArrayType =>
         val arrayType = getAnnotation(array)("scala-array-type")
           .map(_.getValue.getValue.toString)
           .getOrElse(context.params.defaultTypes.array)
         val itemTypeOverride = getAnnotation(array)("scala-type").map(_.getValue.getValue.toString)
         // we do not need to be optional inside an collection, hence setting it to false
+        // also, arrays do not support default values
         TypeRefDetails(
           Type.Apply(
             typeFromName(arrayType),
-            List(
-              scalaTypeRef(array.getItems, false, itemTypeOverride, defaultAnyTypeName).map(
+            scalaTypeRef(array.getItems, false, itemTypeOverride, defaultAnyTypeName)
+              .map(
                 _.scalaType
               )
-            ).flatten
+              .toList
           ),
           None,
-          Some(Term.Select(packageTerm(arrayType), Term.Name("empty")))
+          Some(Term.Select(packageTerm(arrayType), Term.Name("empty"))),
+          isCollection = true
         )
       case objectType: ObjectType if objectType.getName != "object" =>
         TypeRefDetails(Type.Name(objectType.getName), getPackageName(objectType), None)
@@ -446,28 +468,50 @@ object ModelGen {
           )
         )
       case dateTime: DateTimeType =>
-        overrideTypeOr(dateTime, context.params.defaultTypes.dateTime)
+        overrideTypeOr(dateTime, context.params.defaultTypes.dateTime).addDefaultValue(dateTime)
       case date: DateOnlyType =>
-        overrideTypeOr(date, context.params.defaultTypes.date)
+        overrideTypeOr(date, context.params.defaultTypes.date).addDefaultValue(date)
       case time: TimeOnlyType =>
-        overrideTypeOr(time, context.params.defaultTypes.time)
+        overrideTypeOr(time, context.params.defaultTypes.time).addDefaultValue(time)
       case _ => TypeRefDetails(typeFromName(defaultAnyTypeName))
     }
 
-    val typeRef = typeName match {
+    val typeRefDetails = typeName match {
       case Some(scalaTypeName) => TypeRefDetails(typeFromName(scalaTypeName), None, None)
       case None                => mappedType
     }
 
-    if (optional) {
-      Some(
-        TypeRef(
-          Type.Apply(Type.Name("Option"), List(typeRef.baseType)),
-          typeRef.packageName,
-          Some(Term.Name("None"))
+    typeRefDetails match {
+      case details: TypeRefDetails if !optional =>
+        Some(TypeRef(details.baseType, details.packageName, details.defaultValue))
+
+      case TypeRefDetails(baseType, packageName, Some(_), true) =>
+        Some(
+          TypeRef(
+            Type.Apply(Type.Name("Option"), List(baseType)),
+            packageName,
+            Some(q"None")
+          )
         )
-      )
-    } else Some(TypeRef(typeRef.baseType, typeRef.packageName, typeRef.defaultValue))
+
+      case TypeRefDetails(baseType, packageName, Some(defaultValue), false) =>
+        Some(
+          TypeRef(
+            Type.Apply(Type.Name("Option"), List(baseType)),
+            packageName,
+            Some(q"Some($defaultValue)")
+          )
+        )
+
+      case TypeRefDetails(baseType, packageName, None, _) =>
+        Some(
+          TypeRef(
+            Type.Apply(Type.Name("Option"), List(baseType)),
+            packageName,
+            Some(q"None")
+          )
+        )
+    }
   }
 
   def scalaProperty(prop: TypedElement)(fallbackType: String)(implicit

--- a/src/main/scala/scraml/RMFUtil.scala
+++ b/src/main/scala/scraml/RMFUtil.scala
@@ -3,7 +3,7 @@ package scraml
 import cats.effect.IO
 import io.vrap.rmf.raml.model.RamlModelBuilder
 import io.vrap.rmf.raml.model.modules.Api
-import io.vrap.rmf.raml.model.types.{Annotation, AnyType, ObjectType, Property}
+import io.vrap.rmf.raml.model.types.{Annotation, AnyType, ObjectType, Property, StringType}
 import org.eclipse.emf.common.util.URI
 import java.io.File
 import scala.collection.immutable.TreeSet
@@ -22,6 +22,13 @@ object RMFUtil {
     override def compare(x: AnyType, y: AnyType): Int =
       x.getName.compareTo(y.getName)
   }
+
+  /** determines if '''string''' is an `enum` and not an aliased string.
+    */
+  def isEnumType(string: StringType): Boolean =
+    (string.getName ne null) &&
+      (string.getName != "string") &&
+      Option(string.getType).flatMap(t => Option(t.getEnum)).exists(!_.isEmpty)
 
   /** get all sub-types of '''aType''', excluding '''aType'''.
     */

--- a/src/main/scala/scraml/libs/RefinedSupport.scala
+++ b/src/main/scala/scraml/libs/RefinedSupport.scala
@@ -4,15 +4,7 @@ import scala.meta._
 
 import _root_.io.vrap.rmf.raml.model.types._
 import _root_.io.vrap.rmf.raml.model.values.RegExp
-import scraml.{
-  AdditionalProperties,
-  DefnWithCompanion,
-  FieldMatchPolicy,
-  LibrarySupport,
-  MetaUtil,
-  ModelGenContext,
-  RMFUtil
-}
+import scraml._
 
 object RefinedSupport extends LibrarySupport {
   import LibrarySupport.appendObjectStats
@@ -135,6 +127,13 @@ object RefinedSupport extends LibrarySupport {
         optional: Boolean
     )(implicit context: ModelGenContext): Option[A] = None
 
+    protected def integer(
+        definingType: ObjectType,
+        name: Name,
+        descriptor: IntegerType,
+        optional: Boolean
+    )(implicit context: ModelGenContext): Option[A] = None
+
     protected def number(
         definingType: ObjectType,
         name: Name,
@@ -219,10 +218,16 @@ object RefinedSupport extends LibrarySupport {
       definition match {
         case Some((obj, at: ArrayType, required)) =>
           array(obj, name, at, !required)
+
+        case Some((obj, it: IntegerType, required)) =>
+          integer(obj, name, it, !required)
+
         case Some((obj, nt: NumberType, required)) =>
           number(obj, name, nt, !required)
+
         case Some((obj, st: StringType, required)) =>
           string(obj, name, st, !required)
+
         case _ =>
           None
       }
@@ -241,6 +246,14 @@ object RefinedSupport extends LibrarySupport {
         definingType: ObjectType,
         name: Name,
         descriptor: ArrayType,
+        optional: Boolean
+    )(implicit context: ModelGenContext): Option[Term] =
+      constructorArg(name, optional, sourceIsFaceted(name))
+
+    override protected def integer(
+        definingType: ObjectType,
+        name: Name,
+        descriptor: IntegerType,
         optional: Boolean
     )(implicit context: ModelGenContext): Option[Term] =
       constructorArg(name, optional, sourceIsFaceted(name))
@@ -315,11 +328,25 @@ object RefinedSupport extends LibrarySupport {
         optional: Boolean
     )(implicit context: ModelGenContext): Option[(Type, Option[Term])] = {
       Some(
-        mkDeclType(context.objectType, name.value) -> defaultValue(optional) {
-          q"None"
+        mkDeclType(context.objectType, name.value) -> defaultValue(descriptor, optional) {
+          None
         }
       )
     }
+
+    override protected def integer(
+        definingType: ObjectType,
+        name: Name,
+        descriptor: IntegerType,
+        optional: Boolean
+    )(implicit context: ModelGenContext): Option[(Type, Option[Term])] =
+      Some(
+        mkDeclType(context.objectType, name.value) -> defaultValue(descriptor, optional) {
+          Some(
+            q"${Term.Name(context.objectType.getName)}.${Term.Name(mkTypeName(name.value).value)}.default"
+          )
+        }
+      )
 
     override protected def number(
         definingType: ObjectType,
@@ -328,8 +355,10 @@ object RefinedSupport extends LibrarySupport {
         optional: Boolean
     )(implicit context: ModelGenContext): Option[(Type, Option[Term])] =
       Some(
-        mkDeclType(context.objectType, name.value) -> defaultValue(optional) {
-          q"None"
+        mkDeclType(context.objectType, name.value) -> defaultValue(descriptor, optional) {
+          Some(
+            q"${Term.Name(context.objectType.getName)}.${Term.Name(mkTypeName(name.value).value)}.default"
+          )
         }
       )
 
@@ -340,18 +369,19 @@ object RefinedSupport extends LibrarySupport {
         optional: Boolean
     )(implicit context: ModelGenContext): Option[(Type, Option[Term])] =
       Some(
-        mkDeclType(context.objectType, name.value) -> defaultValue(optional) {
-          q"None"
+        mkDeclType(context.objectType, name.value) -> defaultValue(descriptor, optional) {
+          Some(
+            q"${Term.Name(context.objectType.getName)}.${Term.Name(mkTypeName(name.value).value)}.default"
+          )
         }
       )
 
-    private def defaultValue(optional: Boolean)(
-        value: => Term
+    private def defaultValue(descriptor: AnyType, optional: Boolean)(
+        value: => Option[Term]
     ): Option[Term] =
-      if (optional)
-        Some(value)
-      else
-        None
+      Option(descriptor.getDefault)
+        .flatMap(_ => value)
+        .orElse(Some(q"None").filter(_ => optional))
   }
 
   object RefinedPropertyItemPredicates extends RefinedPropertyMatching[List[Type.Apply]] {
@@ -440,6 +470,18 @@ object RefinedSupport extends LibrarySupport {
       }
     }
 
+    override protected def integer(
+        definingType: ObjectType,
+        name: Name,
+        descriptor: IntegerType,
+        optional: Boolean
+    )(implicit context: ModelGenContext): Option[List[Type.Apply]] = {
+      val min = Option(descriptor.getMinimum)
+      val max = Option(descriptor.getMaximum)
+
+      Some(numberBounds(min.map(BigDecimal(_)), max.map(BigDecimal(_))))
+    }
+
     override protected def number(
         definingType: ObjectType,
         name: Name,
@@ -500,6 +542,14 @@ object RefinedSupport extends LibrarySupport {
           Some((mkTypeName(name.value), None, optional))
       }
     }
+
+    override protected def integer(
+        definingType: ObjectType,
+        name: Name,
+        descriptor: IntegerType,
+        optional: Boolean
+    )(implicit context: ModelGenContext): Option[(Type.Name, Option[Type.Name], Boolean)] =
+      Some((mkTypeName(name.value), None, optional))
 
     override protected def number(
         definingType: ObjectType,
@@ -603,7 +653,13 @@ object RefinedSupport extends LibrarySupport {
               q"""
                 type $typeName = Option[Refined[$originalType,${predicates(prop)}]]
                 """,
-              refinedTypeObject(typeName, originalType, predicates(prop), true)
+              refinedTypeObject(
+                typeName,
+                originalType,
+                prop,
+                optional = true,
+                collection = true
+              )
             )
 
           case RefinedPropertyType(typeName, Some(itemName), _) =>
@@ -620,7 +676,13 @@ object RefinedSupport extends LibrarySupport {
 
             itemPredicates ++ List[Stat](
               q"type $typeName = Refined[$originalType,${predicates(prop)}]",
-              refinedTypeObject(typeName, originalType, predicates(prop), false)
+              refinedTypeObject(
+                typeName,
+                originalType,
+                prop,
+                optional = false,
+                collection = true
+              )
             )
 
           case RefinedPropertyType(typeName, None, optional) if optional =>
@@ -628,13 +690,25 @@ object RefinedSupport extends LibrarySupport {
               q"""
                 type $typeName = Option[Refined[$originalType,${predicates(prop)}]]
                 """,
-              refinedTypeObject(typeName, originalType, predicates(prop), true)
+              refinedTypeObject(
+                typeName,
+                originalType,
+                prop,
+                optional = true,
+                collection = false
+              )
             )
 
           case RefinedPropertyType(typeName, None, _) =>
             List[Stat](
               q"type $typeName = Refined[$originalType,${predicates(prop)}]",
-              refinedTypeObject(typeName, originalType, predicates(prop), false)
+              refinedTypeObject(
+                typeName,
+                originalType,
+                prop,
+                optional = false,
+                collection = false
+              )
             )
 
           case _ =>
@@ -894,47 +968,110 @@ object RefinedSupport extends LibrarySupport {
   private def refinedTypeObject(
       typeName: Type.Name,
       originalType: Type,
-      predicates: Type,
-      optional: Boolean
-  ): Defn.Object = {
+      param: Term.Param,
+      optional: Boolean,
+      collection: Boolean
+  )(implicit context: ModelGenContext): Defn.Object = {
     /// These "companion-like" object definitions are inspired by the refined
     /// `RefTypeOps` class.
-    if (optional)
-      q"""
+    param.default match {
+      case Some(term) if !collection && !optional =>
+        q"""
+        object ${Term.Name(typeName.value)} {
+          import eu.timepit.refined.api._
+
+          type ResultType = Refined[$originalType,${predicates(param)}]
+
+          private val rt = RefinedType.apply[ResultType]
+
+          lazy val default: ResultType = unsafeFrom($term)
+
+          def apply(candidate: $originalType): Either[IllegalArgumentException, ResultType] =
+            from(candidate)
+
+          def from(candidate: $originalType): Either[IllegalArgumentException, ResultType] =
+            rt.refine(candidate).left.map(msg => new IllegalArgumentException(msg))
+
+          def unapply(candidate: $originalType): Option[ResultType] =
+            from(candidate).toOption
+
+          def unsafeFrom(candidate: $originalType): ResultType =
+            rt.unsafeRefine(candidate)
+        }
+       """
+
+      case Some(term) if !collection && optional =>
+        q"""
+        object ${Term.Name(typeName.value)} {
+          import eu.timepit.refined.api._
+
+          type ResultType = Refined[$originalType,${predicates(param)}]
+
+          private val rt = RefinedType.apply[ResultType]
+
+          lazy val default: Option[ResultType] = unsafeFrom($term)
+
+          def apply(candidate: $originalType): Either[IllegalArgumentException, Option[ResultType]] =
+            from(Option(candidate))
+
+          def apply(candidate: Option[$originalType]): Either[IllegalArgumentException, Option[ResultType]] =
+            from(candidate)
+
+          def from(candidate: Option[$originalType]): Either[IllegalArgumentException, Option[ResultType]] =
+            candidate match {
+              case Some(value) =>
+                rt.refine(value).map(Some(_)).left.map(msg => new IllegalArgumentException(msg))
+              case None =>
+                Right(None)
+            }
+
+          def unapply(candidate: Option[$originalType]): Option[ResultType] =
+            from(candidate).fold(_ => None, a => a)
+
+          def unsafeFrom(candidate: Option[$originalType]): Option[ResultType] =
+            candidate.map(rt.unsafeRefine)
+        }
+       """
+
+      case _ if optional =>
+        q"""
+        object ${Term.Name(typeName.value)} {
+          import eu.timepit.refined.api._
+
+          type ResultType = Refined[$originalType,${predicates(param)}]
+
+          private val rt = RefinedType.apply[ResultType]
+
+          lazy val default: Option[ResultType] = None
+
+          def apply(candidate: $originalType): Either[IllegalArgumentException, Option[ResultType]] =
+            from(Option(candidate))
+
+          def apply(candidate: Option[$originalType]): Either[IllegalArgumentException, Option[ResultType]] =
+            from(candidate)
+
+          def from(candidate: Option[$originalType]): Either[IllegalArgumentException, Option[ResultType]] =
+            candidate match {
+              case Some(value) =>
+                rt.refine(value).map(Some(_)).left.map(msg => new IllegalArgumentException(msg))
+              case None =>
+                Right(None)
+            }
+
+          def unapply(candidate: Option[$originalType]): Option[ResultType] =
+            from(candidate).fold(_ => None, a => a)
+
+          def unsafeFrom(candidate: Option[$originalType]): Option[ResultType] =
+            candidate.map(rt.unsafeRefine)
+        }
+       """
+
+      case _ =>
+        q"""
       object ${Term.Name(typeName.value)} {
         import eu.timepit.refined.api._
 
-        type ResultType = Refined[$originalType,$predicates]
-
-        private val rt = RefinedType.apply[ResultType]
-
-        def apply(candidate: $originalType): Either[IllegalArgumentException, Option[ResultType]] =
-          from(Option(candidate))
-
-        def apply(candidate: Option[$originalType]): Either[IllegalArgumentException, Option[ResultType]] =
-          from(candidate)
-
-        def from(candidate: Option[$originalType]): Either[IllegalArgumentException, Option[ResultType]] =
-          candidate match {
-            case Some(value) =>
-              rt.refine(value).map(Some(_)).left.map(msg => new IllegalArgumentException(msg))
-            case None =>
-              Right(None)
-          }
-
-        def unapply(candidate: Option[$originalType]): Option[ResultType] =
-          from(candidate).fold(_ => None, a => a)
-
-        def unsafeFrom(candidate: Option[$originalType]): Option[ResultType] =
-          candidate.map(rt.unsafeRefine)
-      }
-     """
-    else
-      q"""
-      object ${Term.Name(typeName.value)} {
-        import eu.timepit.refined.api._
-
-        type ResultType = Refined[$originalType,$predicates]
+        type ResultType = Refined[$originalType,${predicates(param)}]
 
         private val rt = RefinedType.apply[ResultType]
 
@@ -951,6 +1088,7 @@ object RefinedSupport extends LibrarySupport {
           rt.unsafeRefine(candidate)
       }
      """
+    }
   }
 
   private def warnWhenMultipleFacets(declaration: Member)(implicit

--- a/src/main/scala/scraml/libs/RefinedSupport.scala
+++ b/src/main/scala/scraml/libs/RefinedSupport.scala
@@ -225,7 +225,7 @@ object RefinedSupport extends LibrarySupport {
         case Some((obj, nt: NumberType, required)) =>
           number(obj, name, nt, !required)
 
-        case Some((obj, st: StringType, required)) =>
+        case Some((obj, st: StringType, required)) if !RMFUtil.isEnumType(st) =>
           string(obj, name, st, !required)
 
         case _ =>

--- a/src/sbt-test/sbt-scraml/json/api/constrainedstring.raml
+++ b/src/sbt-test/sbt-scraml/json/api/constrainedstring.raml
@@ -1,0 +1,7 @@
+#%RAML 1.0 DataType
+(package): DataTypes
+displayName: ConstrainedString
+type: string
+description: |
+  This is a string in which has a content restriction
+pattern: ^[A-Z]{2}$

--- a/src/sbt-test/sbt-scraml/json/api/defaultproperty.raml
+++ b/src/sbt-test/sbt-scraml/json/api/defaultproperty.raml
@@ -1,0 +1,16 @@
+#%RAML 1.0 DataType
+(package): DataTypes
+(docs-uri): "https://example.org/default-property"
+displayName: DefaultProperty
+type: object
+(scala-derive-json): true
+properties:
+  message:
+    type: string
+    default: "this is a default message"
+    minLength: 4
+    maxLength: 64
+    pattern: "^[A-z0-9 ]*$"
+  limit?:
+    type: integer
+    default: 2

--- a/src/sbt-test/sbt-scraml/json/api/defaultproperty.raml
+++ b/src/sbt-test/sbt-scraml/json/api/defaultproperty.raml
@@ -14,3 +14,13 @@ properties:
   limit?:
     type: integer
     default: 2
+  requiredEnum:
+    type: SomeEnum
+    default: B
+  optionalEnum:
+    type: SomeEnum
+    default: A
+    required: false
+  constrained:
+    type: ConstrainedString
+    default: AA

--- a/src/sbt-test/sbt-scraml/json/api/types.raml
+++ b/src/sbt-test/sbt-scraml/json/api/types.raml
@@ -11,3 +11,4 @@ NoSealedBase: !include nosealedbase.raml
 OtherSub: !include othersub.raml
 MapLike: !include maplike.raml
 SomeEnum: !include enum.raml
+DefaultProperty: !include defaultproperty.raml

--- a/src/sbt-test/sbt-scraml/json/api/types.raml
+++ b/src/sbt-test/sbt-scraml/json/api/types.raml
@@ -12,3 +12,5 @@ OtherSub: !include othersub.raml
 MapLike: !include maplike.raml
 SomeEnum: !include enum.raml
 DefaultProperty: !include defaultproperty.raml
+ConstrainedString: !include constrainedstring.raml
+

--- a/src/sbt-test/sbt-scraml/json/build.sbt
+++ b/src/sbt-test/sbt-scraml/json/build.sbt
@@ -3,7 +3,7 @@ val circeVersion = "0.14.1"
 lazy val root = (project in file("."))
   .settings(
     name := "scraml-json-test",
-    scalaVersion := "2.12.14",
+    scalaVersion := "2.12.15",
     version := "0.1",
     ramlFile := Some(file("api/json.raml")),
     basePackageName := "scraml",

--- a/src/sbt-test/sbt-scraml/json/src/main/scala/scraml/JsonTest.scala
+++ b/src/sbt-test/sbt-scraml/json/src/main/scala/scraml/JsonTest.scala
@@ -8,6 +8,7 @@ object JsonTest extends App {
 
   checkIntermediate()
   checkAdditional()
+  checkDefault()
 
 
   def checkIntermediate(): Unit = {
@@ -64,6 +65,17 @@ object JsonTest extends App {
       parse(grandchild.asJson.toString) == Right(grandchild.asJson),
       s"JSON did not round trip:\nparse: ${parse(grandchild.asJson.toString)}"
     )
+  }
+
+  def checkDefault(): Unit = {
+    val default = DefaultProperty()()
+
+    assert(default.message ne null)
+    assert(default.message != "")
+    assert(default.asJson == DefaultProperty.encoder(default))
+    assert(default.asJson.toString.contains("message"))
+    assert(default.asJson.toString.contains(default.message))
+    assert(default.asJson.toString.contains(default.limit.fold("<<missing>>")(_.toString)))
   }
 }
 

--- a/src/sbt-test/sbt-scraml/refined/api/constrainedstring.raml
+++ b/src/sbt-test/sbt-scraml/refined/api/constrainedstring.raml
@@ -1,0 +1,7 @@
+#%RAML 1.0 DataType
+(package): DataTypes
+displayName: ConstrainedString
+type: string
+description: |
+  This is a string in which has a content restriction
+pattern: ^[A-Z]{2}$

--- a/src/sbt-test/sbt-scraml/refined/api/defaultproperty.raml
+++ b/src/sbt-test/sbt-scraml/refined/api/defaultproperty.raml
@@ -16,3 +16,13 @@ properties:
     default: 2
     minimum: 0
     maximum: 20
+  requiredEnum:
+    type: SomeEnum
+    default: B
+  optionalEnum:
+    type: SomeEnum
+    default: A
+    required: false
+  constrained:
+    type: ConstrainedString
+    default: AA

--- a/src/sbt-test/sbt-scraml/refined/api/defaultproperty.raml
+++ b/src/sbt-test/sbt-scraml/refined/api/defaultproperty.raml
@@ -1,0 +1,18 @@
+#%RAML 1.0 DataType
+(package): DataTypes
+(docs-uri): "https://example.org/default-property"
+displayName: DefaultProperty
+type: object
+(scala-derive-json): true
+properties:
+  message:
+    type: string
+    default: "this is a default message"
+    minLength: 4
+    maxLength: 64
+    pattern: "^[A-z0-9 ]*$"
+  limit?:
+    type: integer
+    default: 2
+    minimum: 0
+    maximum: 20

--- a/src/sbt-test/sbt-scraml/refined/api/types.raml
+++ b/src/sbt-test/sbt-scraml/refined/api/types.raml
@@ -16,3 +16,6 @@ SomeMapType: !include somemaptype.raml
 
 # Verify support for default values with other facets
 DefaultProperty: !include defaultproperty.raml
+
+# Verify support for top-level strings with facets
+ConstrainedString: !include constrainedstring.raml

--- a/src/sbt-test/sbt-scraml/refined/api/types.raml
+++ b/src/sbt-test/sbt-scraml/refined/api/types.raml
@@ -4,7 +4,7 @@ EmptyBase: !include emptybase.raml
 NoProps: !include noprops.raml
 SomeEnum: !include enum.raml
 
-# Verify inherited facets defintions
+# Verify inherited facets definitions
 BaseWithoutFacetsType: !include basewithoutfacetstype.raml
 ChildWithFacetsType: !include childwithfacetstype.raml
 
@@ -13,3 +13,6 @@ ChildInheritsAll: !include childinheritsall.raml
 ChildOverridesAll: !include childoverridesall.raml
 
 SomeMapType: !include somemaptype.raml
+
+# Verify support for default values with other facets
+DefaultProperty: !include defaultproperty.raml

--- a/src/sbt-test/sbt-scraml/refined/src/main/scala/scraml/RefinedTest.scala
+++ b/src/sbt-test/sbt-scraml/refined/src/main/scala/scraml/RefinedTest.scala
@@ -7,6 +7,7 @@ import io.circe.syntax._
 object RefinedTest extends App {
   checkNoAdditional()
   checkAdditional()
+  checkDefault()
 
 
   def checkNoAdditional(): Unit = {
@@ -89,6 +90,18 @@ object RefinedTest extends App {
       dataTypeWith.flatMap(np => parse(np.asJson.toString)) == dataTypeWith.map(_.asJson),
       s"JSON did not round trip:\nparse: ${dataTypeWith.flatMap(np => parse(np.asJson.toString))}"
     )
+  }
+
+  def checkDefault(): Unit = {
+    val default = DefaultProperty()
+
+    assert(default.message == DefaultProperty.MessageType.default)
+    assert(default.limit == DefaultProperty.LimitType.default)
+    assert(default.limit.isDefined)
+    assert(default.asJson == DefaultProperty.encoder(default))
+    assert(default.asJson.toString.contains("message"))
+    assert(default.asJson.toString.contains(default.message.value))
+    assert(default.asJson.toString.contains(default.limit.fold("<<missing>>")(_.value.toString)))
   }
 }
 

--- a/src/sbt-test/sbt-scraml/simple/api/defaultproperty.raml
+++ b/src/sbt-test/sbt-scraml/simple/api/defaultproperty.raml
@@ -1,0 +1,10 @@
+#%RAML 1.0 DataType
+(package): DataTypes
+(docs-uri): "https://example.org/default-property"
+displayName: DefaultProperty
+type: object
+(scala-derive-json): true
+properties:
+  message:
+    type: string
+    default: "this is a default message"

--- a/src/sbt-test/sbt-scraml/simple/api/types.raml
+++ b/src/sbt-test/sbt-scraml/simple/api/types.raml
@@ -1,5 +1,6 @@
 BaseType: !include basetype.raml
 DataType: !include datatype.raml
+DefaultProperty: !include defaultproperty.raml
 EmptyBase: !include emptybase.raml
 NoProps: !include noprops.raml
 SomeEnum: !include enum.raml

--- a/src/test/scala/scraml/DefaultModelGenSpec.scala
+++ b/src/test/scala/scraml/DefaultModelGenSpec.scala
@@ -22,7 +22,7 @@ class DefaultModelGenSpec extends AnyFlatSpec with Matchers {
     val generated = ModelGenRunner.run(DefaultModelGen)(params).unsafeRunSync()
 
     generated.files match {
-      case baseType :: dataType :: emptyBase :: noProps :: enumType :: packageObject :: Nil =>
+      case baseType :: dataType :: defaultProperty :: emptyBase :: noProps :: enumType :: packageObject :: Nil =>
         baseType.source.packageName should be("datatypes")
         baseType.source.source.toString() should be(
           "sealed trait BaseType extends Any { def id: String }"
@@ -41,6 +41,16 @@ class DefaultModelGenSpec extends AnyFlatSpec with Matchers {
         dataType.source.name should be("DataType")
         dataType.file.getPath should be("target/scraml-test/scraml/datatypes.scala")
 
+        defaultProperty.source.packageName should be("datatypes")
+        defaultProperty.source.name should be("DefaultProperty")
+        defaultProperty.file.getPath should be("target/scraml-test/scraml/datatypes.scala")
+        defaultProperty.source.source.toString() should be(
+          """final case class DefaultProperty(message: String = "this is a default message")"""
+        )
+        defaultProperty.source.companion.map(_.toString()) should be(
+          Some("""object DefaultProperty""")
+        )
+
         emptyBase.source.source.toString() should be("sealed trait EmptyBase")
         noProps.source.source.toString() should be(
           s"""case object NoProps extends EmptyBase""".stripMargin
@@ -54,7 +64,7 @@ class DefaultModelGenSpec extends AnyFlatSpec with Matchers {
 
         packageObject.source.source.toString should be("package object scraml")
 
-      case _ => fail()
+      case _ => fail("unexpected number of generated source files")
     }
   }
 

--- a/src/test/scala/scraml/SphereJsonSupportSpec.scala
+++ b/src/test/scala/scraml/SphereJsonSupportSpec.scala
@@ -22,7 +22,7 @@ class SphereJsonSupportSpec extends AnyFlatSpec with Matchers {
     val generated = ModelGenRunner.run(DefaultModelGen)(params).unsafeRunSync()
 
     generated.files match {
-      case noDiscBase :: _ :: _ :: baseType :: _ :: _ :: dataType :: emptyBase :: noProps :: _ :: someEnum :: _ :: _ :: _ :: Nil =>
+      case noDiscBase :: _ :: _ :: baseType :: _ :: _ :: dataType :: emptyBase :: noProps :: _ :: someEnum :: _ :: _ :: _ :: _ :: Nil =>
         noDiscBase.source.source.toString() should be("sealed trait NoDiscriminatorBase")
         noDiscBase.source.companion.map(_.toString()) should be(
           Some(s"""object NoDiscriminatorBase {

--- a/src/test/scala/scraml/libs/CirceJsonSupportSpec.scala
+++ b/src/test/scala/scraml/libs/CirceJsonSupportSpec.scala
@@ -40,6 +40,7 @@ class CirceJsonSupportSpec extends AnyFlatSpec with Matchers with SourceCodeForm
           noProps ::
           noSealedBase ::
           someEnum ::
+          defaultProperty ::
           otherSub ::
           mapLike ::
           packageObject ::
@@ -290,13 +291,37 @@ class CirceJsonSupportSpec extends AnyFlatSpec with Matchers with SourceCodeForm
         grandchildType.source.companion.map(_.toString().stripTrailingSpaces) should be(
           Some(
             s"""object GrandchildType {
-                                                                            |  import io.circe._
-                                                                            |  import io.circe.generic.semiauto._
-                                                                            |  import io.circe.syntax._
-                                                                            |  import scraml.Formats._
-                                                                            |  implicit lazy val decoder: Decoder[GrandchildType] = deriveDecoder[GrandchildType]
-                                                                            |  implicit lazy val encoder: Encoder[GrandchildType] = deriveEncoder[GrandchildType].mapJsonObject(_.+:("type" -> Json.fromString("grandchild")))
-                                                                            |}""".stripMargin.stripTrailingSpaces
+              |  import io.circe._
+              |  import io.circe.generic.semiauto._
+              |  import io.circe.syntax._
+              |  import scraml.Formats._
+              |  implicit lazy val decoder: Decoder[GrandchildType] = deriveDecoder[GrandchildType]
+              |  implicit lazy val encoder: Encoder[GrandchildType] = deriveEncoder[GrandchildType].mapJsonObject(_.+:("type" -> Json.fromString("grandchild")))
+              |}""".stripMargin.stripTrailingSpaces
+          )
+        )
+
+        defaultProperty.source.source.toString().stripTrailingSpaces should be(
+          """final case class DefaultProperty(message: String = "this is a default message", limit: Option[Int] = Some(2))"""
+        )
+        defaultProperty.source.companion.map(_.toString().stripTrailingSpaces) should be(
+          Some(
+            s"""object DefaultProperty {
+               |  import io.circe._
+               |  import io.circe.generic.semiauto._
+               |  import io.circe.syntax._
+               |  import scraml.Formats._
+               |  implicit lazy val decoder: Decoder[DefaultProperty] = new Decoder[DefaultProperty] {
+               |    def apply(c: HCursor): Decoder.Result[DefaultProperty] = {
+               |      c.getOrElse[String]("message")("this is a default message").flatMap { (_message: String) =>
+               |        c.getOrElse[Option[Int]]("limit")(Some(2)).map {
+               |          (_limit: Option[Int]) => DefaultProperty(_message, _limit)
+               |        }
+               |      }
+               |    }
+               |  }
+               |  implicit lazy val encoder: Encoder[DefaultProperty] = deriveEncoder[DefaultProperty]
+               |}""".stripMargin.stripTrailingSpaces
           )
         )
     }
@@ -334,6 +359,7 @@ class CirceJsonSupportSpec extends AnyFlatSpec with Matchers with SourceCodeForm
           noProps ::
           noSealedBase ::
           someEnum ::
+          defaultProperty ::
           otherSub ::
           mapLike ::
           packageObject ::
@@ -447,8 +473,8 @@ class CirceJsonSupportSpec extends AnyFlatSpec with Matchers with SourceCodeForm
                  |        c.downField("foo").as[Option[String]].flatMap { (_foo: Option[String]) =>
                  |          c.downField("customTypeProp").as[scala.math.BigDecimal].flatMap { (_customTypeProp: scala.math.BigDecimal) =>
                  |            c.downField("customArrayTypeProp").as[Vector[scala.math.BigDecimal]].flatMap { (_customArrayTypeProp: Vector[scala.math.BigDecimal]) =>
-                 |              AdditionalProperties.decoder(c).flatMap {
-                 |                (_additionalProperties: Option[DataType.AdditionalProperties]) => Right(DataType(_id, _foo, _customTypeProp, _customArrayTypeProp)(_additionalProperties))
+                 |              AdditionalProperties.decoder(c).map {
+                 |                (_additionalProperties: Option[DataType.AdditionalProperties]) => DataType(_id, _foo, _customTypeProp, _customArrayTypeProp)(_additionalProperties)
                  |              }
                  |            }
                  |          }
@@ -536,8 +562,8 @@ class CirceJsonSupportSpec extends AnyFlatSpec with Matchers with SourceCodeForm
               |  import scraml.Formats._
               |  implicit lazy val decoder: Decoder[NoProps] = new Decoder[NoProps] {
               |    def apply(c: HCursor): Decoder.Result[NoProps] = {
-              |      AdditionalProperties.decoder(c).flatMap {
-              |        (_additionalProperties: Option[NoProps.AdditionalProperties]) => Right(NoProps()(_additionalProperties))
+              |      AdditionalProperties.decoder(c).map {
+              |        (_additionalProperties: Option[NoProps.AdditionalProperties]) => NoProps()(_additionalProperties)
               |      }
               |    }
               |  }
@@ -671,8 +697,8 @@ class CirceJsonSupportSpec extends AnyFlatSpec with Matchers with SourceCodeForm
               |  implicit lazy val decoder: Decoder[OtherSub] = new Decoder[OtherSub] {
               |    def apply(c: HCursor): Decoder.Result[OtherSub] = {
               |      c.downField("id").as[String].flatMap { (_id: String) =>
-              |        AdditionalProperties.decoder(c).flatMap {
-              |          (_additionalProperties: Option[OtherSub.AdditionalProperties]) => Right(OtherSub(_id)(_additionalProperties))
+              |        AdditionalProperties.decoder(c).map {
+              |          (_additionalProperties: Option[OtherSub.AdditionalProperties]) => OtherSub(_id)(_additionalProperties)
               |        }
               |      }
               |    }
@@ -784,8 +810,8 @@ class CirceJsonSupportSpec extends AnyFlatSpec with Matchers with SourceCodeForm
               |                c.downField("aLong").as[scala.math.BigInt].flatMap { (_aLong: scala.math.BigInt) =>
               |                  c.downField("customTypeProp").as[scala.math.BigDecimal].flatMap { (_customTypeProp: scala.math.BigDecimal) =>
               |                    c.downField("customArrayTypeProp").as[Vector[scala.math.BigDecimal]].flatMap { (_customArrayTypeProp: Vector[scala.math.BigDecimal]) =>
-              |                      AdditionalProperties.decoder(c).flatMap {
-              |                        (_additionalProperties: Option[GrandchildType.AdditionalProperties]) => Right(GrandchildType(_id, _foo, _aDouble, _aFloat, _anInt, _aLong, _customTypeProp, _customArrayTypeProp)(_additionalProperties))
+              |                      AdditionalProperties.decoder(c).map {
+              |                        (_additionalProperties: Option[GrandchildType.AdditionalProperties]) => GrandchildType(_id, _foo, _aDouble, _aFloat, _anInt, _aLong, _customTypeProp, _customArrayTypeProp)(_additionalProperties)
               |                      }
               |                    }
               |                  }
@@ -799,6 +825,73 @@ class CirceJsonSupportSpec extends AnyFlatSpec with Matchers with SourceCodeForm
               |  }
               |  implicit lazy val encoder: Encoder[GrandchildType] = new Encoder[GrandchildType] { final def apply(instance: GrandchildType): Json = AdditionalProperties.merge(Json.obj("type" -> Json.fromString("grandchild"), "id" -> instance.id.asJson, "foo" -> instance.foo.asJson, "aDouble" -> instance.aDouble.asJson, "aFloat" -> instance.aFloat.asJson, "anInt" -> instance.anInt.asJson, "aLong" -> instance.aLong.asJson, "customTypeProp" -> instance.customTypeProp.asJson, "customArrayTypeProp" -> instance.customArrayTypeProp.asJson), instance.additionalProperties) }
               |}""".stripMargin.stripTrailingSpaces
+          )
+        )
+
+        defaultProperty.source.source.toString().stripTrailingSpaces should be(
+          """final case class DefaultProperty(message: String = "this is a default message", limit: Option[Int] = Some(2))(val additionalProperties: Option[DefaultProperty.AdditionalProperties] = None)"""
+        )
+        defaultProperty.source.companion.map(_.toString().stripTrailingSpaces) should be(
+          Some(
+            s"""object DefaultProperty {
+               |  import scala.language.dynamics
+               |  final case class AdditionalProperties(private val underlying: scala.collection.immutable.Map[String, io.circe.Json]) extends scala.Dynamic {
+               |    override def toString(): String = underlying.mkString(", ")
+               |    def selectDynamic(field: String): Option[io.circe.Json] = underlying.get(field)
+               |    def getOrElse[V >: io.circe.Json](key: String, default: => V): V = underlying.getOrElse(key, default)
+               |    def isDefinedAt(key: String): Boolean = underlying.isDefinedAt(key)
+               |    def isEmpty: Boolean = underlying.isEmpty
+               |    def keySet: Set[String] = underlying.keySet
+               |    def keys: Iterable[String] = underlying.keys
+               |    def keysIterator: Iterator[String] = underlying.keysIterator
+               |    def nonEmpty: Boolean = !underlying.isEmpty
+               |    def size: Int = underlying.size
+               |    def values: Iterable[io.circe.Json] = underlying.values
+               |    def valuesIterator: Iterator[io.circe.Json] = underlying.valuesIterator
+               |  }
+               |  object AdditionalProperties {
+               |    import scala.util.matching.Regex
+               |    val propertyNames: Seq[String] = Seq("message", "limit")
+               |    val allowedNames: Seq[Regex] = Seq()
+               |    import io.circe._
+               |    import io.circe.generic.semiauto._
+               |    implicit lazy val decoder: Decoder[Option[AdditionalProperties]] = new Decoder[Option[AdditionalProperties]] {
+               |      final def apply(c: HCursor): Decoder.Result[Option[AdditionalProperties]] = {
+               |        val allKeys = c.keys.fold(Set.empty[String])(_.toSet)
+               |        Right(Option(allKeys.filterNot(propertyNames.contains)).filterNot(_.isEmpty).map {
+               |          _.foldLeft(scala.collection.immutable.Map.newBuilder[String, Json])({
+               |            case (accum, key) =>
+               |              c.downField(key).focus.fold(accum) {
+               |                v => accum += key -> v
+               |              }
+               |          })
+               |        }.map(b => AdditionalProperties(b.result())))
+               |      }
+               |    }
+               |    def merge(into: Json, oap: Option[AdditionalProperties]): Json = {
+               |      oap.fold(into)(merge(into, _))
+               |    }
+               |    def merge(into: Json, ap: AdditionalProperties): Json = {
+               |      Json.fromFields(ap.underlying).deepMerge(into)
+               |    }
+               |  }
+               |  import io.circe._
+               |  import io.circe.generic.semiauto._
+               |  import io.circe.syntax._
+               |  import scraml.Formats._
+               |  implicit lazy val decoder: Decoder[DefaultProperty] = new Decoder[DefaultProperty] {
+               |    def apply(c: HCursor): Decoder.Result[DefaultProperty] = {
+               |      c.getOrElse[String]("message")("this is a default message").flatMap { (_message: String) =>
+               |        c.getOrElse[Option[Int]]("limit")(Some(2)).flatMap { (_limit: Option[Int]) =>
+               |          AdditionalProperties.decoder(c).map {
+               |            (_additionalProperties: Option[DefaultProperty.AdditionalProperties]) => DefaultProperty(_message, _limit)(_additionalProperties)
+               |          }
+               |        }
+               |      }
+               |    }
+               |  }
+               |  implicit lazy val encoder: Encoder[DefaultProperty] = new Encoder[DefaultProperty] { final def apply(instance: DefaultProperty): Json = AdditionalProperties.merge(Json.obj("message" -> instance.message.asJson, "limit" -> instance.limit.asJson), instance.additionalProperties) }
+               |}""".stripMargin.stripTrailingSpaces
           )
         )
     }

--- a/src/test/scala/scraml/libs/RefinedSupportSpec.scala
+++ b/src/test/scala/scraml/libs/RefinedSupportSpec.scala
@@ -91,6 +91,7 @@ class RefinedSupportSpec extends AnyWordSpec with Matchers with SourceCodeFormat
             |    import eu.timepit.refined.api._
             |    type ResultType = Refined[Set[scala.math.BigDecimal], And[MinSize[Witness.`1`.T], And[MaxSize[Witness.`100`.T], Forall[OptionalCustomArrayTypePropItemPredicate]]]]
             |    private val rt = RefinedType.apply[ResultType]
+            |    lazy val default: Option[ResultType] = None
             |    def apply(candidate: Set[scala.math.BigDecimal]): Either[IllegalArgumentException, Option[ResultType]] = from(Option(candidate))
             |    def apply(candidate: Option[Set[scala.math.BigDecimal]]): Either[IllegalArgumentException, Option[ResultType]] = from(candidate)
             |    def from(candidate: Option[Set[scala.math.BigDecimal]]): Either[IllegalArgumentException, Option[ResultType]] = candidate match {
@@ -107,6 +108,7 @@ class RefinedSupportSpec extends AnyWordSpec with Matchers with SourceCodeFormat
             |    import eu.timepit.refined.api._
             |    type ResultType = Refined[String, MatchesRegex[Witness.`"^[A-z]+$"`.T]]
             |    private val rt = RefinedType.apply[ResultType]
+            |    lazy val default: Option[ResultType] = unsafeFrom(None)
             |    def apply(candidate: String): Either[IllegalArgumentException, Option[ResultType]] = from(Option(candidate))
             |    def apply(candidate: Option[String]): Either[IllegalArgumentException, Option[ResultType]] = from(candidate)
             |    def from(candidate: Option[String]): Either[IllegalArgumentException, Option[ResultType]] = candidate match {
@@ -155,6 +157,7 @@ class RefinedSupportSpec extends AnyWordSpec with Matchers with SourceCodeFormat
             |    import eu.timepit.refined.api._
             |    type ResultType = Refined[scala.collection.immutable.List[String], Forall[OptionalStringArrayItemPredicate]]
             |    private val rt = RefinedType.apply[ResultType]
+            |    lazy val default: Option[ResultType] = None
             |    def apply(candidate: scala.collection.immutable.List[String]): Either[IllegalArgumentException, Option[ResultType]] = from(Option(candidate))
             |    def apply(candidate: Option[scala.collection.immutable.List[String]]): Either[IllegalArgumentException, Option[ResultType]] = from(candidate)
             |    def from(candidate: Option[scala.collection.immutable.List[String]]): Either[IllegalArgumentException, Option[ResultType]] = candidate match {
@@ -280,6 +283,7 @@ class RefinedSupportSpec extends AnyWordSpec with Matchers with SourceCodeFormat
             |    import eu.timepit.refined.api._
             |    type ResultType = Refined[Set[scala.math.BigDecimal], And[MinSize[Witness.`1`.T], And[MaxSize[Witness.`100`.T], Forall[OptionalCustomArrayTypePropItemPredicate]]]]
             |    private val rt = RefinedType.apply[ResultType]
+            |    lazy val default: Option[ResultType] = None
             |    def apply(candidate: Set[scala.math.BigDecimal]): Either[IllegalArgumentException, Option[ResultType]] = from(Option(candidate))
             |    def apply(candidate: Option[Set[scala.math.BigDecimal]]): Either[IllegalArgumentException, Option[ResultType]] = from(candidate)
             |    def from(candidate: Option[Set[scala.math.BigDecimal]]): Either[IllegalArgumentException, Option[ResultType]] = candidate match {
@@ -296,6 +300,7 @@ class RefinedSupportSpec extends AnyWordSpec with Matchers with SourceCodeFormat
             |    import eu.timepit.refined.api._
             |    type ResultType = Refined[String, MatchesRegex[Witness.`"^[A-z]+$"`.T]]
             |    private val rt = RefinedType.apply[ResultType]
+            |    lazy val default: Option[ResultType] = unsafeFrom(None)
             |    def apply(candidate: String): Either[IllegalArgumentException, Option[ResultType]] = from(Option(candidate))
             |    def apply(candidate: Option[String]): Either[IllegalArgumentException, Option[ResultType]] = from(candidate)
             |    def from(candidate: Option[String]): Either[IllegalArgumentException, Option[ResultType]] = candidate match {
@@ -344,6 +349,7 @@ class RefinedSupportSpec extends AnyWordSpec with Matchers with SourceCodeFormat
             |    import eu.timepit.refined.api._
             |    type ResultType = Refined[scala.collection.immutable.List[String], Forall[OptionalStringArrayItemPredicate]]
             |    private val rt = RefinedType.apply[ResultType]
+            |    lazy val default: Option[ResultType] = None
             |    def apply(candidate: scala.collection.immutable.List[String]): Either[IllegalArgumentException, Option[ResultType]] = from(Option(candidate))
             |    def apply(candidate: Option[scala.collection.immutable.List[String]]): Either[IllegalArgumentException, Option[ResultType]] = from(candidate)
             |    def from(candidate: Option[scala.collection.immutable.List[String]]): Either[IllegalArgumentException, Option[ResultType]] = candidate match {
@@ -512,6 +518,7 @@ class RefinedSupportSpec extends AnyWordSpec with Matchers with SourceCodeFormat
             |    import eu.timepit.refined.api._
             |    type ResultType = Refined[Set[scala.math.BigDecimal], And[MinSize[Witness.`1`.T], And[MaxSize[Witness.`100`.T], Forall[OptionalCustomArrayTypePropItemPredicate]]]]
             |    private val rt = RefinedType.apply[ResultType]
+            |    lazy val default: Option[ResultType] = None
             |    def apply(candidate: Set[scala.math.BigDecimal]): Either[IllegalArgumentException, Option[ResultType]] = from(Option(candidate))
             |    def apply(candidate: Option[Set[scala.math.BigDecimal]]): Either[IllegalArgumentException, Option[ResultType]] = from(candidate)
             |    def from(candidate: Option[Set[scala.math.BigDecimal]]): Either[IllegalArgumentException, Option[ResultType]] = candidate match {
@@ -528,6 +535,7 @@ class RefinedSupportSpec extends AnyWordSpec with Matchers with SourceCodeFormat
             |    import eu.timepit.refined.api._
             |    type ResultType = Refined[String, MatchesRegex[Witness.`"^[A-z]+$"`.T]]
             |    private val rt = RefinedType.apply[ResultType]
+            |    lazy val default: Option[ResultType] = unsafeFrom(None)
             |    def apply(candidate: String): Either[IllegalArgumentException, Option[ResultType]] = from(Option(candidate))
             |    def apply(candidate: Option[String]): Either[IllegalArgumentException, Option[ResultType]] = from(candidate)
             |    def from(candidate: Option[String]): Either[IllegalArgumentException, Option[ResultType]] = candidate match {
@@ -576,6 +584,7 @@ class RefinedSupportSpec extends AnyWordSpec with Matchers with SourceCodeFormat
             |    import eu.timepit.refined.api._
             |    type ResultType = Refined[scala.collection.immutable.List[String], Forall[OptionalStringArrayItemPredicate]]
             |    private val rt = RefinedType.apply[ResultType]
+            |    lazy val default: Option[ResultType] = None
             |    def apply(candidate: scala.collection.immutable.List[String]): Either[IllegalArgumentException, Option[ResultType]] = from(Option(candidate))
             |    def apply(candidate: Option[scala.collection.immutable.List[String]]): Either[IllegalArgumentException, Option[ResultType]] = from(candidate)
             |    def from(candidate: Option[scala.collection.immutable.List[String]]): Either[IllegalArgumentException, Option[ResultType]] = candidate match {
@@ -952,6 +961,105 @@ class RefinedSupportSpec extends AnyWordSpec with Matchers with SourceCodeFormat
             |            (__stringArray: StringArrayType) => ChildInheritsAll(__id, __count, __atMost100, __stringArray)
             |          }
             |        }
+            |      }
+            |    }
+            |  }
+            |}""".stripMargin.stripTrailingSpaces
+        )
+      )
+    }
+
+    "support default values (scalar)" in {
+      val params = ModelGenParams(
+        new File("src/sbt-test/sbt-scraml/refined/api/refined.raml"),
+        new File("target/scraml-refined-test"),
+        "scraml",
+        FieldMatchPolicy.Exact(),
+        DefaultTypes(),
+        librarySupport = Set(CirceJsonSupport(), RefinedSupport),
+        formatConfig = None,
+        generateDateCreated = true
+      )
+
+      val generated = ModelGenRunner.run(DefaultModelGen)(params).unsafeRunSync()
+
+      generated.files.nonEmpty should be(true)
+
+      val theSource = generated.files
+        .find(_.source.name == "DefaultProperty")
+        .map(_.source.source.toString().stripTrailingSpaces)
+
+      val theCompanion = generated.files
+        .find(_.source.name == "DefaultProperty")
+        .flatMap(_.source.companion)
+        .map(_.toString().stripTrailingSpaces)
+
+      theSource.isDefined should be(true)
+      theCompanion.isDefined should be(true)
+
+      theSource should be(
+        Some(
+          """final case class DefaultProperty(message: DefaultProperty.MessageType = DefaultProperty.MessageType.default, limit: DefaultProperty.LimitType = DefaultProperty.LimitType.default)"""
+        )
+      )
+
+      theCompanion should be(
+        Some(
+          """object DefaultProperty {
+            |  import io.circe._
+            |  import io.circe.generic.semiauto._
+            |  import io.circe.syntax._
+            |  import io.circe.refined._
+            |  implicit lazy val decoder: Decoder[DefaultProperty] = new Decoder[DefaultProperty] {
+            |    def apply(c: HCursor): Decoder.Result[DefaultProperty] = {
+            |      c.getOrElse[String]("message")("this is a default message").flatMap { (_message: String) =>
+            |        c.getOrElse[Option[Int]]("limit")(Some(2)).flatMap {
+            |          (_limit: Option[Int]) => DefaultProperty.from(_message, _limit).swap.map(e => DecodingFailure(e.getMessage, Nil)).swap
+            |        }
+            |      }
+            |    }
+            |  }
+            |  implicit lazy val encoder: Encoder[DefaultProperty] = deriveEncoder[DefaultProperty]
+            |  import eu.timepit.refined.api.Refined
+            |  import eu.timepit.refined.boolean.And
+            |  import eu.timepit.refined.collection._
+            |  import eu.timepit.refined.numeric._
+            |  import eu.timepit.refined.string._
+            |  import shapeless.Witness
+            |  type MessageType = Refined[String, And[MinSize[Witness.`4`.T], And[MaxSize[Witness.`64`.T], MatchesRegex[Witness.`"^[A-z0-9 ]*$"`.T]]]]
+            |  object MessageType {
+            |    import eu.timepit.refined.api._
+            |    type ResultType = Refined[String, And[MinSize[Witness.`4`.T], And[MaxSize[Witness.`64`.T], MatchesRegex[Witness.`"^[A-z0-9 ]*$"`.T]]]]
+            |    private val rt = RefinedType.apply[ResultType]
+            |    lazy val default: ResultType = unsafeFrom("this is a default message")
+            |    def apply(candidate: String): Either[IllegalArgumentException, ResultType] = from(candidate)
+            |    def from(candidate: String): Either[IllegalArgumentException, ResultType] = rt.refine(candidate).left.map(msg => new IllegalArgumentException(msg))
+            |    def unapply(candidate: String): Option[ResultType] = from(candidate).toOption
+            |    def unsafeFrom(candidate: String): ResultType = rt.unsafeRefine(candidate)
+            |  }
+            |  type LimitType = Option[Refined[Int, Interval.Closed[Witness.`0`.T, Witness.`20`.T]]]
+            |  object LimitType {
+            |    import eu.timepit.refined.api._
+            |    type ResultType = Refined[Int, Interval.Closed[Witness.`0`.T, Witness.`20`.T]]
+            |    private val rt = RefinedType.apply[ResultType]
+            |    lazy val default: Option[ResultType] = unsafeFrom(Some(2))
+            |    def apply(candidate: Int): Either[IllegalArgumentException, Option[ResultType]] = from(Option(candidate))
+            |    def apply(candidate: Option[Int]): Either[IllegalArgumentException, Option[ResultType]] = from(candidate)
+            |    def from(candidate: Option[Int]): Either[IllegalArgumentException, Option[ResultType]] = candidate match {
+            |      case Some(value) =>
+            |        rt.refine(value).map(Some(_)).left.map(msg => new IllegalArgumentException(msg))
+            |      case None =>
+            |        Right(None)
+            |    }
+            |    def unapply(candidate: Option[Int]): Option[ResultType] = from(candidate).fold(_ => None, a => a)
+            |    def unsafeFrom(candidate: Option[Int]): Option[ResultType] = candidate.map(rt.unsafeRefine)
+            |  }
+            |  def from(message: String = "this is a default message", limit: Option[Int] = Some(2)): Either[IllegalArgumentException, DefaultProperty] = {
+            |    val _message = MessageType.from(message)
+            |    val _limit = LimitType.from(limit)
+            |    _message.flatMap { (__message: MessageType) =>
+            |      _limit.map {
+            |        (__limit: LimitType) => DefaultProperty(__message, __limit)
             |      }
             |    }
             |  }

--- a/src/test/scala/scraml/libs/RefinedSupportSpec.scala
+++ b/src/test/scala/scraml/libs/RefinedSupportSpec.scala
@@ -999,7 +999,7 @@ class RefinedSupportSpec extends AnyWordSpec with Matchers with SourceCodeFormat
 
       theSource should be(
         Some(
-          """final case class DefaultProperty(message: DefaultProperty.MessageType = DefaultProperty.MessageType.default, limit: DefaultProperty.LimitType = DefaultProperty.LimitType.default)"""
+          """final case class DefaultProperty(message: DefaultProperty.MessageType = DefaultProperty.MessageType.default, limit: DefaultProperty.LimitType = DefaultProperty.LimitType.default, requiredEnum: SomeEnum = SomeEnum.B, optionalEnum: Option[SomeEnum] = Some(SomeEnum.A), constrained: String = "AA")"""
         )
       )
 
@@ -1013,8 +1013,14 @@ class RefinedSupportSpec extends AnyWordSpec with Matchers with SourceCodeFormat
             |  implicit lazy val decoder: Decoder[DefaultProperty] = new Decoder[DefaultProperty] {
             |    def apply(c: HCursor): Decoder.Result[DefaultProperty] = {
             |      c.getOrElse[String]("message")("this is a default message").flatMap { (_message: String) =>
-            |        c.getOrElse[Option[Int]]("limit")(Some(2)).flatMap {
-            |          (_limit: Option[Int]) => DefaultProperty.from(_message, _limit).swap.map(e => DecodingFailure(e.getMessage, Nil)).swap
+            |        c.getOrElse[Option[Int]]("limit")(Some(2)).flatMap { (_limit: Option[Int]) =>
+            |          c.getOrElse[SomeEnum]("requiredEnum")(SomeEnum.B).flatMap { (_requiredEnum: SomeEnum) =>
+            |            c.getOrElse[Option[SomeEnum]]("optionalEnum")(Some(SomeEnum.A)).flatMap { (_optionalEnum: Option[SomeEnum]) =>
+            |              c.getOrElse[String]("constrained")("AA").flatMap {
+            |                (_constrained: String) => DefaultProperty.from(_message, _limit, _requiredEnum, _optionalEnum, _constrained).swap.map(e => DecodingFailure(e.getMessage, Nil)).swap
+            |              }
+            |            }
+            |          }
             |        }
             |      }
             |    }
@@ -1054,12 +1060,21 @@ class RefinedSupportSpec extends AnyWordSpec with Matchers with SourceCodeFormat
             |    def unapply(candidate: Option[Int]): Option[ResultType] = from(candidate).fold(_ => None, a => a)
             |    def unsafeFrom(candidate: Option[Int]): Option[ResultType] = candidate.map(rt.unsafeRefine)
             |  }
-            |  def from(message: String = "this is a default message", limit: Option[Int] = Some(2)): Either[IllegalArgumentException, DefaultProperty] = {
+            |  def from(message: String = "this is a default message", limit: Option[Int] = Some(2), requiredEnum: SomeEnum = SomeEnum.B, optionalEnum: Option[SomeEnum] = Some(SomeEnum.A), constrained: String = "AA"): Either[IllegalArgumentException, DefaultProperty] = {
             |    val _message = MessageType.from(message)
             |    val _limit = LimitType.from(limit)
+            |    val _requiredEnum = Right(requiredEnum)
+            |    val _optionalEnum = Right(optionalEnum)
+            |    val _constrained = Right(constrained)
             |    _message.flatMap { (__message: MessageType) =>
-            |      _limit.map {
-            |        (__limit: LimitType) => DefaultProperty(__message, __limit)
+            |      _limit.flatMap { (__limit: LimitType) =>
+            |        _requiredEnum.flatMap { (__requiredEnum: SomeEnum) =>
+            |          _optionalEnum.flatMap { (__optionalEnum: Option[SomeEnum]) =>
+            |            _constrained.map {
+            |              (__constrained: String) => DefaultProperty(__message, __limit, __requiredEnum, __optionalEnum, __constrained)
+            |            }
+            |          }
+            |        }
             |      }
             |    }
             |  }


### PR DESCRIPTION
Resolves #30

* `default` property values are supported for scalars
* `default` property values are supported for `enum`s
* optional properties have a `Some` if there is a default
* added `integer` refined type support
* increased integration test coverage