### PR TITLE
Fixed enum property types detection

### DIFF
--- a/src/main/scala/scraml/DefaultModelGen.scala
+++ b/src/main/scala/scraml/DefaultModelGen.scala
@@ -201,7 +201,7 @@ object DefaultModelGen extends ModelGen {
       packageName <- IO.fromOption(
         getPackageName(objectType).orElse(params.defaultPackageAnnotation)
       )(
-        new IllegalStateException("object type should have package name")
+        new IllegalStateException("object type should have package name: " + objectType.getName)
       )
       apiBaseType = Option[AnyType](objectType.getType)
       extendType = getAnnotation(objectType)("scala-extends")

--- a/src/main/scala/scraml/ModelGen.scala
+++ b/src/main/scala/scraml/ModelGen.scala
@@ -442,8 +442,7 @@ object ModelGen {
       // we would need to generate types for property types otherwise
       case string: StringType
           if (string.getName eq null) ||
-            (apiType.eContainer().eClass().getName == "Property" && string.getName == "string") ||
-            Option(string.getType).flatMap(t => Option(t.getEnum)).exists(_.isEmpty) =>
+            (apiType.eContainer().eClass().getName == "Property" && string.getName == "string") =>
         TypeRefDetails(typeFromName(context.params.defaultTypes.string)).addDefaultValue(string)
 
       case stringEnum: StringType if isEnumType(stringEnum) =>

--- a/src/main/scala/scraml/RMFUtil.scala
+++ b/src/main/scala/scraml/RMFUtil.scala
@@ -27,8 +27,10 @@ object RMFUtil {
     */
   def isEnumType(string: StringType): Boolean =
     (string.getName ne null) &&
-      (string.getName != "string") &&
-      Option(string.getType).flatMap(t => Option(t.getEnum)).exists(!_.isEmpty)
+      (string.getName != "string") && (
+        Option(string.getEnum).exists(!_.isEmpty) ||
+          Option(string.getType).flatMap(t => Option(t.getEnum)).exists(!_.isEmpty)
+      )
 
   /** get all sub-types of '''aType''', excluding '''aType'''.
     */

--- a/src/sbt-test/sbt-scraml/simple/api/simple.raml
+++ b/src/sbt-test/sbt-scraml/simple/api/simple.raml
@@ -8,6 +8,8 @@ types: !include types.raml
 /greeting: # optional resource
   get: # HTTP method declaration
     queryParameters:
+      enum_type:
+        type: SomeEnum
       name?:
         type: string
     responses: # declare a response

--- a/src/test/scala/scraml/libs/TapirSupportSpec.scala
+++ b/src/test/scala/scraml/libs/TapirSupportSpec.scala
@@ -26,57 +26,59 @@ final class TapirSupportSpec
 
       val generated = ModelGenRunner.run(DefaultModelGen)(params).unsafeRunSync()
 
-      generated.packageObject.source.source.toString should be(s"""package object scraml {
-                                                                  |  import io.circe.Decoder.Result
-                                                                  |  import io.circe.{ HCursor, Json, Decoder, Encoder }
-                                                                  |  implicit def eitherEncoder[A, B](implicit aEncoder: Encoder[A], bEncoder: Encoder[B]): Encoder[Either[A, B]] = new Encoder[Either[A, B]] {
-                                                                  |    override def apply(a: Either[A, B]): Json = a match {
-                                                                  |      case Right(b) =>
-                                                                  |        bEncoder(b)
-                                                                  |      case Left(a) =>
-                                                                  |        aEncoder(a)
-                                                                  |    }
-                                                                  |  }
-                                                                  |  implicit def eitherDecoder[A, B](implicit aDecoder: Decoder[A], bDecoder: Decoder[B]): Decoder[Either[A, B]] = new Decoder[Either[A, B]] { override def apply(c: HCursor): Result[Either[A, B]] = aDecoder.either(bDecoder)(c) }
-                                                                  |  import sttp.tapir._
-                                                                  |  import sttp.model._
-                                                                  |  import sttp.tapir.CodecFormat.TextPlain
-                                                                  |  import sttp.tapir.json.circe._
-                                                                  |  type |[+A1, +A2] = Either[A1, A2]
-                                                                  |  private implicit def anySchema[T]: Schema[T] = Schema[T](SchemaType.SCoproduct(Nil, None)(_ => None), None)
-                                                                  |  private implicit def eitherTapirCodecPlain[A, B](implicit aCodec: Codec.PlainCodec[A], bCodec: Codec.PlainCodec[B]): Codec.PlainCodec[Either[A, B]] = new Codec.PlainCodec[Either[A, B]] {
-                                                                  |    override val format = TextPlain()
-                                                                  |    override val schema = anySchema[Either[A, B]]
-                                                                  |    override def rawDecode(l: String): DecodeResult[Either[A, B]] = {
-                                                                  |      aCodec.rawDecode(l) match {
-                                                                  |        case e: DecodeResult.Failure =>
-                                                                  |          bCodec.rawDecode(l).map(Right(_))
-                                                                  |        case other =>
-                                                                  |          other.map(Left(_))
-                                                                  |      }
-                                                                  |    }
-                                                                  |    override def encode(h: Either[A, B]): String = {
-                                                                  |      h match {
-                                                                  |        case Left(a) =>
-                                                                  |          aCodec.encode(a)
-                                                                  |        case Right(b) =>
-                                                                  |          bCodec.encode(b)
-                                                                  |      }
-                                                                  |    }
-                                                                  |  }
-                                                                  |  private implicit val queryOptionalCollectionCodec: Codec[List[String], Option[scala.collection.immutable.List[String]], TextPlain] = new Codec[List[String], Option[scala.collection.immutable.List[String]], TextPlain] {
-                                                                  |    override def rawDecode(l: List[String]): DecodeResult[Option[scala.collection.immutable.List[String]]] = DecodeResult.Value(Some(l.to[scala.collection.immutable.List]))
-                                                                  |    override def encode(h: Option[scala.collection.immutable.List[String]]): List[String] = h.map(_.to[List]).getOrElse(Nil)
-                                                                  |    override lazy val schema: Schema[Option[scala.collection.immutable.List[String]]] = Schema.binary
-                                                                  |    override lazy val format: TextPlain = TextPlain()
-                                                                  |  }
-                                                                  |  object Endpoints {
-                                                                  |    object Greeting {
-                                                                  |      final case class GetGreetingParams(name: Option[String] = None)
-                                                                  |      val getGreeting = endpoint.get.in("greeting").in(query[Option[String]]("name")).mapInTo[GetGreetingParams].out(jsonBody[DataType])
-                                                                  |    }
-                                                                  |  }
-                                                                  |}""".stripMargin)
+      generated.packageObject.source.source.toString should be(
+        """package object scraml {
+        |  import io.circe.Decoder.Result
+        |  import io.circe.{ HCursor, Json, Decoder, Encoder }
+        |  implicit def eitherEncoder[A, B](implicit aEncoder: Encoder[A], bEncoder: Encoder[B]): Encoder[Either[A, B]] = new Encoder[Either[A, B]] {
+        |    override def apply(a: Either[A, B]): Json = a match {
+        |      case Right(b) =>
+        |        bEncoder(b)
+        |      case Left(a) =>
+        |        aEncoder(a)
+        |    }
+        |  }
+        |  implicit def eitherDecoder[A, B](implicit aDecoder: Decoder[A], bDecoder: Decoder[B]): Decoder[Either[A, B]] = new Decoder[Either[A, B]] { override def apply(c: HCursor): Result[Either[A, B]] = aDecoder.either(bDecoder)(c) }
+        |  import sttp.tapir._
+        |  import sttp.model._
+        |  import sttp.tapir.CodecFormat.TextPlain
+        |  import sttp.tapir.json.circe._
+        |  type |[+A1, +A2] = Either[A1, A2]
+        |  private implicit def anySchema[T]: Schema[T] = Schema[T](SchemaType.SCoproduct(Nil, None)(_ => None), None)
+        |  private implicit def eitherTapirCodecPlain[A, B](implicit aCodec: Codec.PlainCodec[A], bCodec: Codec.PlainCodec[B]): Codec.PlainCodec[Either[A, B]] = new Codec.PlainCodec[Either[A, B]] {
+        |    override val format = TextPlain()
+        |    override val schema = anySchema[Either[A, B]]
+        |    override def rawDecode(l: String): DecodeResult[Either[A, B]] = {
+        |      aCodec.rawDecode(l) match {
+        |        case e: DecodeResult.Failure =>
+        |          bCodec.rawDecode(l).map(Right(_))
+        |        case other =>
+        |          other.map(Left(_))
+        |      }
+        |    }
+        |    override def encode(h: Either[A, B]): String = {
+        |      h match {
+        |        case Left(a) =>
+        |          aCodec.encode(a)
+        |        case Right(b) =>
+        |          bCodec.encode(b)
+        |      }
+        |    }
+        |  }
+        |  private implicit val queryOptionalCollectionCodec: Codec[List[String], Option[scala.collection.immutable.List[String]], TextPlain] = new Codec[List[String], Option[scala.collection.immutable.List[String]], TextPlain] {
+        |    override def rawDecode(l: List[String]): DecodeResult[Option[scala.collection.immutable.List[String]]] = DecodeResult.Value(Some(l.to[scala.collection.immutable.List]))
+        |    override def encode(h: Option[scala.collection.immutable.List[String]]): List[String] = h.map(_.to[List]).getOrElse(Nil)
+        |    override lazy val schema: Schema[Option[scala.collection.immutable.List[String]]] = Schema.binary
+        |    override lazy val format: TextPlain = TextPlain()
+        |  }
+        |  object Endpoints {
+        |    object Greeting {
+        |      final case class GetGreetingParams(enum_type: SomeEnum, name: Option[String] = None)
+        |      val getGreeting = endpoint.get.in("greeting").in(query[SomeEnum]("enum_type") and query[Option[String]]("name")).mapInTo[GetGreetingParams].out(jsonBody[DataType])
+        |    }
+        |  }
+        |}""".stripMargin
+      )
     }
 
     "generate enumeration types" in {


### PR DESCRIPTION
Using `enum`s in tapir query parameters identified two
defects in the type detection logic.  This change fixes
those issues.