### PR TITLE
Fixed parsing defaults for large numeric types

### DIFF
--- a/src/main/scala/scraml/ModelGen.scala
+++ b/src/main/scala/scraml/ModelGen.scala
@@ -9,6 +9,7 @@ import java.io.File
 import scala.collection.immutable.TreeSet
 import scala.meta._
 import scala.reflect.ClassTag
+import scala.util.Try
 
 import sbt.internal.util.ManagedLogger
 
@@ -408,6 +409,19 @@ object ModelGen {
             val raw = instance.getValue.toString
 
             copy(defaultValue = Option(Lit.String(raw)))
+
+          case int: NumberType
+              if (int.getFormat ne null) &&
+                (int.getFormat == NumberFormat.INT64 || int.getFormat == NumberFormat.LONG) =>
+            val parsed = Try(instance.getValue.toString.toLong).map(Lit.Long(_)).toOption
+
+            copy(defaultValue = parsed)
+
+          case double: NumberType
+              if (double.getFormat ne null) && (double.getFormat == NumberFormat.DOUBLE) =>
+            val parsed = Try(instance.getValue.toString.toDouble).map(Lit.Double(_)).toOption
+
+            copy(defaultValue = parsed)
 
           case _ =>
             copy(defaultValue = instance.getValue.toString.parse[Term].toOption)

--- a/src/sbt-test/sbt-scraml/simple/api/defaultproperty.raml
+++ b/src/sbt-test/sbt-scraml/simple/api/defaultproperty.raml
@@ -8,3 +8,7 @@ properties:
   message:
     type: string
     default: "this is a default message"
+  longDefault:
+    type: number
+    format: int64
+    default: -9223372036854775808

--- a/src/test/scala/scraml/DefaultModelGenSpec.scala
+++ b/src/test/scala/scraml/DefaultModelGenSpec.scala
@@ -45,7 +45,7 @@ class DefaultModelGenSpec extends AnyFlatSpec with Matchers {
         defaultProperty.source.name should be("DefaultProperty")
         defaultProperty.file.getPath should be("target/scraml-test/scraml/datatypes.scala")
         defaultProperty.source.source.toString() should be(
-          """final case class DefaultProperty(message: String = "this is a default message")"""
+          """final case class DefaultProperty(message: String = "this is a default message", longDefault: Long = -9223372036854775808L)"""
         )
         defaultProperty.source.companion.map(_.toString()) should be(
           Some("""object DefaultProperty""")


### PR DESCRIPTION
Explicit detection of defaults for 'int64', 'long', and 'double'
numeric types was added so that values outside the domain of
smaller forms could be successfully parsed.