### PR TITLE
(gen): allow to specify custom types for `asMap`

### DIFF
--- a/src/main/scala/scraml/ModelGen.scala
+++ b/src/main/scala/scraml/ModelGen.scala
@@ -571,6 +571,7 @@ object ModelGen {
   private def mapTypeToScala(anyTypeName: String): String => Type.Ref = {
     case "string" => Type.Name("String")
     case "any"    => typeFromName(anyTypeName)
+    case other    => typeFromName(other)
   }
 
   def isSingleton(objectType: ObjectType, anyTypeName: String)(implicit

--- a/src/sbt-test/sbt-scraml/json/api/maplike.raml
+++ b/src/sbt-test/sbt-scraml/json/api/maplike.raml
@@ -5,7 +5,7 @@ displayName: MapLike
 type: NoSealedBase
 (asMap):
   key: string
-  value: string
+  value: Long
 discriminatorValue: "map-like"
 properties:
   //:

--- a/src/test/scala/scraml/libs/CirceJsonSupportSpec.scala
+++ b/src/test/scala/scraml/libs/CirceJsonSupportSpec.scala
@@ -185,7 +185,7 @@ class CirceJsonSupportSpec extends AnyFlatSpec with Matchers with SourceCodeForm
           )
         )
         mapLike.source.source.toString().stripTrailingSpaces should be(
-          s"""final case class MapLike(values: scala.collection.immutable.Map[String, String]) extends NoSealedBase""".stripMargin.stripTrailingSpaces
+          s"""final case class MapLike(values: scala.collection.immutable.Map[String, Long]) extends NoSealedBase""".stripMargin.stripTrailingSpaces
         )
 
         mapLike.source.companion.map(_.toString().stripTrailingSpaces) should be(
@@ -195,7 +195,7 @@ class CirceJsonSupportSpec extends AnyFlatSpec with Matchers with SourceCodeForm
                                                                      |  import io.circe.syntax._
                                                                      |  import io.circe.generic.semiauto._
                                                                      |  import io.circe.Decoder.Result
-                                                                     |  implicit lazy val decoder: Decoder[MapLike] = new Decoder[MapLike] { override def apply(c: HCursor): Result[MapLike] = c.as[scala.collection.immutable.Map[String, String]].map(MapLike.apply) }
+                                                                     |  implicit lazy val decoder: Decoder[MapLike] = new Decoder[MapLike] { override def apply(c: HCursor): Result[MapLike] = c.as[scala.collection.immutable.Map[String, Long]].map(MapLike.apply) }
                                                                      |  implicit lazy val encoder: Encoder[MapLike] = new Encoder[MapLike] { override def apply(a: MapLike): Json = a.values.asJson }
                                                                      |}""".stripMargin.stripTrailingSpaces
           )
@@ -610,7 +610,7 @@ class CirceJsonSupportSpec extends AnyFlatSpec with Matchers with SourceCodeForm
           )
         )
         mapLike.source.source.toString().stripTrailingSpaces should be(
-          s"""final case class MapLike(values: scala.collection.immutable.Map[String, String]) extends NoSealedBase""".stripMargin.stripTrailingSpaces
+          s"""final case class MapLike(values: scala.collection.immutable.Map[String, Long]) extends NoSealedBase""".stripMargin.stripTrailingSpaces
         )
 
         mapLike.source.companion.map(_.toString().stripTrailingSpaces) should be(
@@ -620,7 +620,7 @@ class CirceJsonSupportSpec extends AnyFlatSpec with Matchers with SourceCodeForm
               |  import io.circe.syntax._
               |  import io.circe.generic.semiauto._
               |  import io.circe.Decoder.Result
-              |  implicit lazy val decoder: Decoder[MapLike] = new Decoder[MapLike] { override def apply(c: HCursor): Result[MapLike] = c.as[scala.collection.immutable.Map[String, String]].map(MapLike.apply) }
+              |  implicit lazy val decoder: Decoder[MapLike] = new Decoder[MapLike] { override def apply(c: HCursor): Result[MapLike] = c.as[scala.collection.immutable.Map[String, Long]].map(MapLike.apply) }
               |  implicit lazy val encoder: Encoder[MapLike] = new Encoder[MapLike] { override def apply(a: MapLike): Json = a.values.asJson }
               |}""".stripMargin.stripTrailingSpaces
           )


### PR DESCRIPTION
allows specifying custom types in the `asMap` annotation.
for JSON supports, this implicitly assumes that you have a decoder/encoder for that type