### PR TITLE
 Enhance TapirSupport to generate tapir v1.0 code

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,7 @@ inThisBuild(
   )
 )
 
-val circeVersion = "0.14.1"
+val circeVersion = "0.14.2"
 
 lazy val root = (project in file("."))
   .enablePlugins(SbtPlugin, ParadoxSitePlugin, GhpagesPlugin)

--- a/src/main/paradox/migrating.md
+++ b/src/main/paradox/migrating.md
@@ -2,6 +2,10 @@
 
 # Migration Guide
 
+## v0.11.x -> v0.12.x
+
+Version `0.12.0` introduces a breaking change by generating [tapir v1.0](https://tapir.softwaremill.com/en/latest/migrating.html#from-0-20-to-1-0) compatible code, which is not source-compatible with `tapir v0.19+`.  As such, it is recommended to fully regenerate all `scraml` generated Scala code after updating the `tapir` library dependencies in `sbt` build files to at least `1.0.5`.
+
 ## v0.10.x -> v0.11.x
 
 Version `0.11.0` introduces a breaking change when `additionalProperties` support is enabled.  A second constructor argument list is added to these types which did not exist in `0.10.x` and below.

--- a/src/main/scala/scraml/libs/RefinedSupport.scala
+++ b/src/main/scala/scraml/libs/RefinedSupport.scala
@@ -835,8 +835,8 @@ object RefinedSupport extends LibrarySupport {
                  """
 
               case last :: Nil =>
-                val termName  = Term.Name(last.name.value)
-                val paramName = Term.Name("_" + last.name.value)
+                val termName  = Term.Name(propertyNameFrom(last.name))
+                val paramName = Term.Name("_" + propertyNameFrom(last.name))
 
                 q"""
                    $termName.map { $paramName: ${last.decltpe.get} =>

--- a/src/main/scala/scraml/libs/TapirSupport.scala
+++ b/src/main/scala/scraml/libs/TapirSupport.scala
@@ -256,6 +256,7 @@ final class TapirSupport(endpointsObjectName: String) extends LibrarySupport {
         q"""
           val ${Pat.Var(Term.Name(resourceMethodName))} = $endpointWithErrorOut
         """
+
       List(
         ResourceDefinitions(baseResourceName(templateWithoutSlash), paramTypeDef, endpointValueDef)
       )
@@ -325,6 +326,7 @@ final class TapirSupport(endpointsObjectName: String) extends LibrarySupport {
         import sttp.model._
         import sttp.tapir.CodecFormat.TextPlain
         import sttp.tapir.json.circe._
+        import sttp.tapir.generic.auto._
 
         type |[+A1, +A2] = Either[A1, A2]
 
@@ -366,7 +368,7 @@ final class TapirSupport(endpointsObjectName: String) extends LibrarySupport {
               None,
               q"""
                   sttp.tapir.DecodeResult.InvalidValue(
-                    sttp.tapir.ValidationError.Primitive[String](
+                    sttp.tapir.ValidationError[String](
                       sttp.tapir.Validator.enumeration(
                         $enumValuesAsList
                       ),

--- a/src/sbt-test/sbt-scraml/cats/build.sbt
+++ b/src/sbt-test/sbt-scraml/cats/build.sbt
@@ -1,6 +1,6 @@
 lazy val root = (project in file("."))
   .settings(
-    scalaVersion := "2.13.6",
+    scalaVersion := "2.13.8",
     name := "scraml-cats-test",
     version := "0.1",
     ramlFile := Some(file("api/simple.raml")),

--- a/src/sbt-test/sbt-scraml/ct-api-sphere/build.sbt
+++ b/src/sbt-test/sbt-scraml/ct-api-sphere/build.sbt
@@ -2,7 +2,7 @@ val circeVersion = "0.14.1"
 
 lazy val root = (project in file("."))
   .settings(
-    scalaVersion := "2.12.12",
+    scalaVersion := "2.12.16",
     name := "scraml-ct-api-sphere-test",
     version := "0.1",
     ramlFile := Some(file("reference/api-specs/api/api.raml")),

--- a/src/sbt-test/sbt-scraml/json/build.sbt
+++ b/src/sbt-test/sbt-scraml/json/build.sbt
@@ -1,9 +1,9 @@
-val circeVersion = "0.14.1"
+val circeVersion = "0.14.2"
 
 lazy val root = (project in file("."))
   .settings(
     name := "scraml-json-test",
-    scalaVersion := "2.12.15",
+    scalaVersion := "2.12.16",
     version := "0.1",
     ramlFile := Some(file("api/json.raml")),
     basePackageName := "scraml",

--- a/src/sbt-test/sbt-scraml/tapir/api/annotations.raml
+++ b/src/sbt-test/sbt-scraml/tapir/api/annotations.raml
@@ -1,0 +1,25 @@
+# the package will be used as the file name, currently no actual package structure is generated
+package:
+  type: string
+  allowedTargets: TypeDeclaration
+# allows to specify a url for documentation purposes, not reflected in the code currently
+docs-uri:
+  type: string
+# allows to specify all properties will be put into a map
+asMap:
+  type: object
+  properties:
+    key: string
+    value: string
+# allows to override the type used with a full qualified name of a scala type
+scala-type:
+  type: string
+# allows to override the default type for a collection
+scala-array-type:
+  type: string
+# allows to specify an additional supertype like a traited
+scala-extends:
+  type: string
+# allows to control on a granular level if JSON support is enabled for the annotated type
+scala-derive-json:
+  type: boolean

--- a/src/sbt-test/sbt-scraml/tapir/api/basetype.raml
+++ b/src/sbt-test/sbt-scraml/tapir/api/basetype.raml
@@ -1,0 +1,13 @@
+#%RAML 1.0 DataType
+(package): DataTypes
+(docs-uri): "https://example.org/base-type"
+displayName: BaseType
+type: object
+(scala-extends): "Any"
+(scala-derive-json): true
+discriminator: type
+properties:
+  type:
+    type: string
+  id:
+    type: string

--- a/src/sbt-test/sbt-scraml/tapir/api/datatype.raml
+++ b/src/sbt-test/sbt-scraml/tapir/api/datatype.raml
@@ -1,0 +1,20 @@
+#%RAML 1.0 DataType
+(package): DataTypes
+(docs-uri): "https://example.org/data-type"
+displayName: DataType
+type: BaseType
+(scala-derive-json): true
+discriminatorValue: data
+properties:
+  foo?:
+    type: string
+  customTypeProp:
+    (scala-type): "scala.math.BigDecimal"
+    type: number
+  customArrayTypeProp:
+    (scala-array-type): "Vector"
+    type: array
+    (scala-type): "scala.math.BigDecimal"
+    items:
+      type: object
+

--- a/src/sbt-test/sbt-scraml/tapir/api/defaultproperty.raml
+++ b/src/sbt-test/sbt-scraml/tapir/api/defaultproperty.raml
@@ -1,0 +1,14 @@
+#%RAML 1.0 DataType
+(package): DataTypes
+(docs-uri): "https://example.org/default-property"
+displayName: DefaultProperty
+type: object
+(scala-derive-json): true
+properties:
+  message:
+    type: string
+    default: "this is a default message"
+  longDefault:
+    type: number
+    format: int64
+    default: -9223372036854775808

--- a/src/sbt-test/sbt-scraml/tapir/api/derivedwithrequired.raml
+++ b/src/sbt-test/sbt-scraml/tapir/api/derivedwithrequired.raml
@@ -1,0 +1,8 @@
+#%RAML 1.0 DataType
+(package): DataTypes
+(docs-uri): "https://example.org/derived-with-required-id"
+displayName: DerivedWithRequired
+type: ParentWithOption
+(scala-derive-json): true
+properties:
+  id: string

--- a/src/sbt-test/sbt-scraml/tapir/api/emptybase.raml
+++ b/src/sbt-test/sbt-scraml/tapir/api/emptybase.raml
@@ -1,0 +1,9 @@
+#%RAML 1.0 DataType
+(package): DataTypes
+(docs-uri): "https://example.org/empty-base-type"
+displayName: EmptyBase
+type: object
+discriminator: type
+properties:
+  type:
+    type: string

--- a/src/sbt-test/sbt-scraml/tapir/api/enum.raml
+++ b/src/sbt-test/sbt-scraml/tapir/api/enum.raml
@@ -1,0 +1,7 @@
+#%RAML 1.0 DataType
+(package): DataTypes
+displayName: SomeEnum
+type: string
+enum:
+  - A
+  - B

--- a/src/sbt-test/sbt-scraml/tapir/api/locale.raml
+++ b/src/sbt-test/sbt-scraml/tapir/api/locale.raml
@@ -1,0 +1,7 @@
+#%RAML 1.0 DataType
+(package): Common
+displayName: Locale
+type: string
+description: |
+  String matching the pattern `^[a-z]{2}(-[A-Z]{2})?$` representing an [IETF language tag](https://en.wikipedia.org/wiki/IETF_language_tag).
+pattern: ^[a-z]{2}(-[A-Z]{2})?$

--- a/src/sbt-test/sbt-scraml/tapir/api/noprops.raml
+++ b/src/sbt-test/sbt-scraml/tapir/api/noprops.raml
@@ -1,0 +1,7 @@
+#%RAML 1.0 DataType
+(package): DataTypes
+(docs-uri): "https://example.org/no-props"
+displayName: NoProps
+type: EmptyBase
+(scala-derive-json): true
+discriminatorValue: "nope"

--- a/src/sbt-test/sbt-scraml/tapir/api/objectasmap.raml
+++ b/src/sbt-test/sbt-scraml/tapir/api/objectasmap.raml
@@ -1,0 +1,8 @@
+#%RAML 1.0 DataType
+(package): DataTypes
+(docs-uri): "https://example.org/as-map"
+displayName: ObjectAsMap
+type: object
+(asMap):
+  key: Locale
+  value: SomeEnum

--- a/src/sbt-test/sbt-scraml/tapir/api/parentwithoption.raml
+++ b/src/sbt-test/sbt-scraml/tapir/api/parentwithoption.raml
@@ -1,0 +1,11 @@
+#%RAML 1.0 DataType
+(package): DataTypes
+(docs-uri): "https://example.org/parent-with-option-id"
+displayName: ParentWithOption
+type: object
+(scala-derive-json): true
+properties:
+  id?:
+    type: string
+    minLength: 1
+    maxLength: 128

--- a/src/sbt-test/sbt-scraml/tapir/api/tapir.raml
+++ b/src/sbt-test/sbt-scraml/tapir/api/tapir.raml
@@ -1,0 +1,19 @@
+#%RAML 1.0
+title: Hello world # required title
+# taken from https://github.com/raml-org/raml-spec
+annotationTypes: !include annotations.raml
+# this is not optional, the file included here must follow the format shown 'types.raml'
+types: !include types.raml
+
+/greeting: # optional resource
+  get: # HTTP method declaration
+    queryParameters:
+      enum_type:
+        type: SomeEnum
+      name?:
+        type: string
+    responses: # declare a response
+      200: # HTTP status code
+        body: # declare content of response
+          application/json: # media type
+            type: DataType

--- a/src/sbt-test/sbt-scraml/tapir/api/types.raml
+++ b/src/sbt-test/sbt-scraml/tapir/api/types.raml
@@ -1,0 +1,10 @@
+BaseType: !include basetype.raml
+DataType: !include datatype.raml
+DefaultProperty: !include defaultproperty.raml
+DerivedWithRequired: !include derivedwithrequired.raml
+EmptyBase: !include emptybase.raml
+Locale: !include locale.raml
+NoProps: !include noprops.raml
+ObjectAsMap: !include objectasmap.raml
+ParentWithOption: !include parentwithoption.raml
+SomeEnum: !include enum.raml

--- a/src/sbt-test/sbt-scraml/tapir/build.sbt
+++ b/src/sbt-test/sbt-scraml/tapir/build.sbt
@@ -1,25 +1,19 @@
 val circeVersion = "0.14.2"
-val monocleVersion = "3.1.0"
 val refinedVersion = "0.9.27"
 val tapirVersion = "1.0.5"
 
 lazy val root = (project in file("."))
   .settings(
     scalaVersion := "2.13.8",
-    name := "scraml-ct-api-circe-test",
+    name := "scraml-tapir",
     version := "0.1",
-    ramlFile := Some(file("reference/api-specs/api/api.raml")),
-    basePackageName := "de.commercetools.api",
+    ramlFile := Some(file("api/tapir.raml")),
     defaultTypes := scraml.DefaultTypes(
-      array = "scala.collection.immutable.Vector",
       float = "Double",
       number = "scala.math.BigDecimal"
     ),
     librarySupport := Set(
-      scraml.libs.CatsEqSupport,
-      scraml.libs.CatsShowSupport,
       scraml.libs.CirceJsonSupport(),
-      scraml.libs.MonocleOpticsSupport,
       scraml.libs.TapirSupport("Endpoints"),
       scraml.libs.RefinedSupport
     ),
@@ -36,10 +30,7 @@ lazy val root = (project in file("."))
         "io.circe" %% "circe-refined"
     ).map(_ % circeVersion),
     libraryDependencies ++= Seq(
-      "dev.optics" %% "monocle-core",
-      "dev.optics" %% "monocle-macro"
-    ).map(_ % monocleVersion),
-    libraryDependencies += "com.softwaremill.sttp.tapir" %% "tapir-core" % tapirVersion,
-    libraryDependencies += "com.softwaremill.sttp.tapir" %% "tapir-json-circe" % tapirVersion
+      "com.softwaremill.sttp.tapir" %% "tapir-core",
+      "com.softwaremill.sttp.tapir" %% "tapir-json-circe"
+    ).map (_ % tapirVersion)
   )
-

--- a/src/sbt-test/sbt-scraml/tapir/project/build.properties
+++ b/src/sbt-test/sbt-scraml/tapir/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version = 1.6.2

--- a/src/sbt-test/sbt-scraml/tapir/project/plugins.sbt
+++ b/src/sbt-test/sbt-scraml/tapir/project/plugins.sbt
@@ -1,0 +1,5 @@
+sys.props.get("plugin.version") match {
+  case Some(x) => addSbtPlugin("com.commercetools" % "sbt-scraml" % x)
+  case _ => sys.error("""|The system property 'plugin.version' is not defined.
+                         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+}

--- a/src/sbt-test/sbt-scraml/tapir/test
+++ b/src/sbt-test/sbt-scraml/tapir/test
@@ -1,0 +1,3 @@
+> compile
+# compile again, should not yield errors
+> compile

--- a/src/sbt-test/sbt-scraml/two-specifications/build.sbt
+++ b/src/sbt-test/sbt-scraml/two-specifications/build.sbt
@@ -1,6 +1,6 @@
 lazy val root = (project in file("."))
   .settings(
-    scalaVersion := "2.13.6",
+    scalaVersion := "2.13.8",
     name := "scraml-two-specifications",
     version := "0.1",
     librarySupport := Set(

--- a/src/test/scala/scraml/libs/TapirSupportSpec.scala
+++ b/src/test/scala/scraml/libs/TapirSupportSpec.scala
@@ -43,6 +43,7 @@ final class TapirSupportSpec
         |  import sttp.model._
         |  import sttp.tapir.CodecFormat.TextPlain
         |  import sttp.tapir.json.circe._
+        |  import sttp.tapir.generic.auto._
         |  type |[+A1, +A2] = Either[A1, A2]
         |  private implicit def anySchema[T]: Schema[T] = Schema[T](SchemaType.SCoproduct(Nil, None)(_ => None), None)
         |  private implicit def eitherTapirCodecPlain[A, B](implicit aCodec: Codec.PlainCodec[A], bCodec: Codec.PlainCodec[B]): Codec.PlainCodec[Either[A, B]] = new Codec.PlainCodec[Either[A, B]] {
@@ -120,7 +121,7 @@ final class TapirSupportSpec
             |    case "B" =>
             |      sttp.tapir.DecodeResult.Value(B)
             |    case other =>
-            |      sttp.tapir.DecodeResult.InvalidValue(sttp.tapir.ValidationError.Primitive[String](sttp.tapir.Validator.enumeration(List("A", "B")), other) :: Nil)
+            |      sttp.tapir.DecodeResult.InvalidValue(sttp.tapir.ValidationError[String](sttp.tapir.Validator.enumeration(List("A", "B")), other) :: Nil)
             |  })({
             |    case A => "A"
             |    case B => "B"


### PR DESCRIPTION
Recommended tag: `v0.12.0`

This PR addresses critical path items in issue #43 .  The optional effort of seeing whether or not `TapirPackageDefinitions` can be trimmed down is not in the PR (yet).  If the code those `TODO`s document can be removed, then that could be included in this PR or the next planned one as desired.