### PR TITLE
explicit types for implicits

### DIFF
--- a/src/main/scala/scraml/libs/SphereJsonSupport.scala
+++ b/src/main/scala/scraml/libs/SphereJsonSupport.scala
@@ -71,7 +71,9 @@ object SphereJsonSupport extends LibrarySupport with JsonSupport {
                   import io.sphere.json._
                   import org.json4s._
 
-                  implicit val json = new JSON[${Type.Name(context.objectType.getName)}] {
+                  implicit val json: JSON[${Type.Name(
+        context.objectType.getName
+      )}] = new JSON[${Type.Name(context.objectType.getName)}] {
                   override def read(jval: JsonAST.JValue): JValidation[${Type.Name(
         context.objectType.getName
       )}] = ${read.parse[Term].get}
@@ -149,7 +151,7 @@ object SphereJsonSupport extends LibrarySupport with JsonSupport {
   )(enumTrait: Defn.Trait, companion: Option[Defn.Object]): DefnWithCompanion[Defn.Trait] = {
     import scala.jdk.CollectionConverters._
 
-    val toJson = q""" 
+    val toJson = q"""
       implicit lazy val toJson: ToJSON[${Type
       .Name(enumType.getName())}] = ToJSON.stringWriter.contramap(_.toString)
     """
@@ -174,7 +176,7 @@ object SphereJsonSupport extends LibrarySupport with JsonSupport {
         .toList ++ List(other)
     )
 
-    val fromJson = q""" 
+    val fromJson = q"""
     implicit lazy val fromJson: FromJSON[${Type
       .Name(enumType.getName())}] = (jval: JsonAST.JValue) =>
       FromJSON.stringReader

--- a/src/main/scala/scraml/libs/TapirSupport.scala
+++ b/src/main/scala/scraml/libs/TapirSupport.scala
@@ -105,7 +105,7 @@ final class TapirSupport(endpointsObjectName: String) extends LibrarySupport {
 
   case class BodyWithMediaType(mediaType: String, bodyType: Type)
 
-  implicit val bodyOrder = new Ordering[BodyWithMediaType] {
+  implicit val bodyOrder: Ordering[BodyWithMediaType] = new Ordering[BodyWithMediaType] {
     override def compare(x: BodyWithMediaType, y: BodyWithMediaType): Int =
       s"${x.mediaType}${x.bodyType.toString}".compare(s"${y.mediaType}${y.bodyType.toString()}")
   }

--- a/src/test/scala/scraml/SphereJsonSupportSpec.scala
+++ b/src/test/scala/scraml/SphereJsonSupportSpec.scala
@@ -29,7 +29,7 @@ class SphereJsonSupportSpec extends AnyFlatSpec with Matchers {
              |  import io.sphere.json.generic._
              |  import io.sphere.json._
              |  import org.json4s._
-             |  implicit val json = new JSON[NoDiscriminatorBase] {
+             |  implicit val json: JSON[NoDiscriminatorBase] = new JSON[NoDiscriminatorBase] {
              |    override def read(jval: JsonAST.JValue): JValidation[NoDiscriminatorBase] = NoDiscriminatorSub1.json.read(jval).orElse(NoDiscriminatorSub2.json.read(jval))
              |    override def write(value: NoDiscriminatorBase): JsonAST.JValue = value match {
              |      case nodiscriminatorsub1: NoDiscriminatorSub1 =>


### PR DESCRIPTION
Public implicits should have a type.
This helps scalac and [Intellij](https://youtrack.jetbrains.com/issue/SCL-20517/High-and-long-CPU-usage-when-opening-a-scala-file-using-sangria#focus=Comments-27-6433262.0-0)