### PR TITLE
Enhance TapirSupport to support non-string Params property types

### DIFF
--- a/src/main/scala/scraml/DefaultModelGen.scala
+++ b/src/main/scala/scraml/DefaultModelGen.scala
@@ -332,7 +332,7 @@ object DefaultModelGen extends ModelGen {
            |* $dateCreated
            |* ${docsUri
           .map("@see " + _)
-          .orElse(Option(objectType.getDescription))
+          .orElse(Option(objectType.getDescription).map(_.getValue))
           .getOrElse(s"generated type for ${objectType.getName}")}
            |*/""".stripMargin
     } yield GeneratedTypeSource(

--- a/src/main/scala/scraml/libs/TapirSupport.scala
+++ b/src/main/scala/scraml/libs/TapirSupport.scala
@@ -21,8 +21,7 @@ final class TapirSupport(endpointsObjectName: String) extends LibrarySupport {
 
   private val jsonContentType = "application/json"
 
-  private def upperCaseFirst(string: String): String =
-    string.take(1).toUpperCase.concat(string.drop(1))
+  private def upperCaseFirst(string: String): String = string.capitalize
 
   private def removeLeadingSlash(uri: String): String =
     uri.replaceFirst("/", "")
@@ -40,10 +39,16 @@ final class TapirSupport(endpointsObjectName: String) extends LibrarySupport {
 
     resourceNamePathParts.zipWithIndex.map {
       // if the first path part is a variable, it is not part of a resource locator, hence we drop it in the name
-      case (pathParam(_, _), index) if (index == 0 && resourceNamePathParts.length > 1) => ""
+      case (pathParam(_, _), 0) if resourceNamePathParts.length > 1 => ""
       // skip the variable prefix on first level
-      case (pathParam(_, name), index) =>
-        if (index == 0) upperCaseFirst(name) else "By" + upperCaseFirst(name)
+      case (pathParam(_, name), 0) =>
+        upperCaseFirst(name)
+      // prefix with "By" for the first parameter
+      case (pathParam(_, name), 1) =>
+        "By" + upperCaseFirst(name)
+      // prefix with "And" for the the rest of the parameters
+      case (pathParam(_, name), _) =>
+        "And" + upperCaseFirst(name)
       // camel case literals
       case (literal, _) => upperCaseFirst(literal)
     }.mkString

--- a/src/sbt-test/sbt-scraml/tapir/api/datatype.raml
+++ b/src/sbt-test/sbt-scraml/tapir/api/datatype.raml
@@ -1,10 +1,12 @@
 #%RAML 1.0 DataType
 (package): DataTypes
-(docs-uri): "https://example.org/data-type"
+# The (docs-uri) custom facet is absent so that "description" can be verified.
 displayName: DataType
 type: BaseType
 (scala-derive-json): true
 discriminatorValue: data
+description: >
+  Sample concrete BaseType.
 properties:
   foo?:
     type: string

--- a/src/sbt-test/sbt-scraml/tapir/api/datatype.raml
+++ b/src/sbt-test/sbt-scraml/tapir/api/datatype.raml
@@ -1,6 +1,7 @@
 #%RAML 1.0 DataType
 (package): DataTypes
-# The (docs-uri) custom facet is absent so that "description" can be verified.
+# The (docs-uri) custom annotation is absent so that "description" can
+# be verified.
 displayName: DataType
 type: BaseType
 (scala-derive-json): true

--- a/src/sbt-test/sbt-scraml/tapir/api/preamble.raml
+++ b/src/sbt-test/sbt-scraml/tapir/api/preamble.raml
@@ -1,0 +1,8 @@
+#%RAML 1.0 DataType
+(package): DataTypes
+displayName: Preamble
+type: string
+enum:
+  - Hello
+  - Hola
+  - Howdy

--- a/src/sbt-test/sbt-scraml/tapir/api/tapir-complex.raml
+++ b/src/sbt-test/sbt-scraml/tapir/api/tapir-complex.raml
@@ -1,0 +1,37 @@
+#%RAML 1.0
+title: Hello parameterized world # required title
+
+# taken from https://github.com/raml-org/raml-spec
+annotationTypes: !include annotations.raml
+
+# JSON is the default supported media type
+mediaType: application/json
+
+# this is not optional, the file included here must follow the format
+# shown in 'types.raml'
+types: !include types.raml
+
+/greeting/{preamble}/{delay}: # optional resource
+  uriParameters:
+    delay?:
+      description: Simulated delay (in milliseconds)
+      type: integer
+      minimum: 100
+      maximum: 2000
+    preamble:
+      description: Discrete selector for text to prefix greeting.
+      type: Preamble
+  get: # HTTP method declaration
+    queryParameters:
+      name?:
+        type: string
+      repeat?:
+        type: integer
+        minimum: 1
+        maximum: 10
+      uppercase?:
+        type: boolean
+    responses: # declare a response
+      200: # HTTP status code
+        body: # declare content of response
+          type: DataType

--- a/src/sbt-test/sbt-scraml/tapir/api/tapir-complex.raml
+++ b/src/sbt-test/sbt-scraml/tapir/api/tapir-complex.raml
@@ -13,7 +13,7 @@ types: !include types.raml
 
 /greeting/{preamble}/{delay}: # optional resource
   uriParameters:
-    delay?:
+    delay:
       description: Simulated delay (in milliseconds)
       type: integer
       minimum: 100

--- a/src/sbt-test/sbt-scraml/tapir/api/types.raml
+++ b/src/sbt-test/sbt-scraml/tapir/api/types.raml
@@ -7,4 +7,5 @@ Locale: !include locale.raml
 NoProps: !include noprops.raml
 ObjectAsMap: !include objectasmap.raml
 ParentWithOption: !include parentwithoption.raml
+Preamble: !include preamble.raml
 SomeEnum: !include enum.raml

--- a/src/sbt-test/sbt-scraml/tapir/build.sbt
+++ b/src/sbt-test/sbt-scraml/tapir/build.sbt
@@ -7,7 +7,6 @@ lazy val root = (project in file("."))
     scalaVersion := "2.13.8",
     name := "scraml-tapir",
     version := "0.1",
-    ramlFile := Some(file("api/tapir.raml")),
     defaultTypes := scraml.DefaultTypes(
       float = "Double",
       number = "scala.math.BigDecimal"
@@ -16,6 +15,20 @@ lazy val root = (project in file("."))
       scraml.libs.CirceJsonSupport(),
       scraml.libs.TapirSupport("Endpoints"),
       scraml.libs.RefinedSupport
+    ),
+    ramlDefinitions := Seq(
+      scraml.ModelDefinition(
+        raml = file("api/tapir.raml"),
+        basePackage = "scraml.tapir.simple",
+        formatConfig = None,
+        generateDateCreated = true
+      ),
+      scraml.ModelDefinition(
+        raml = file("api/tapir-complex.raml"),
+        basePackage = "scraml.tapir.complex",
+        formatConfig = None,
+        generateDateCreated = true
+      )
     ),
     Compile / sourceGenerators += runScraml,
     libraryDependencies += "com.chuusai" %% "shapeless" % "2.3.7",

--- a/src/test/scala/scraml/libs/TapirSupportSpec.scala
+++ b/src/test/scala/scraml/libs/TapirSupportSpec.scala
@@ -192,8 +192,8 @@ final class TapirSupportSpec
           |  }
           |  object Endpoints {
           |    object Greeting {
-          |      final case class GetGreetingByPreambleAndDelayParams(preamble: String, delay: String, name: Option[String] = None, repeat: Option[Int] = None, uppercase: Option[Boolean] = None)
-          |      val getGreetingByPreambleAndDelay = endpoint.get.in("greeting" / path[String]("preamble") / path[String]("delay")).in(query[Option[String]]("name") and query[Option[Int]]("repeat") and query[Option[Boolean]]("uppercase")).mapInTo[GetGreetingByPreambleAndDelayParams].out(jsonBody[DataType])
+          |      final case class GetGreetingByPreambleAndDelayParams(preamble: Preamble, delay: Option[Int], name: Option[String] = None, repeat: Option[Int] = None, uppercase: Option[Boolean] = None)
+          |      val getGreetingByPreambleAndDelay = endpoint.get.in("greeting" / path[Preamble]("preamble") / path[Option[Int]]("delay")).in(query[Option[String]]("name") and query[Option[Int]]("repeat") and query[Option[Boolean]]("uppercase")).mapInTo[GetGreetingByPreambleAndDelayParams].out(jsonBody[DataType])
           |    }
           |  }
           |}""".stripMargin.stripTrailingSpaces

--- a/src/test/scala/scraml/libs/TapirSupportSpec.scala
+++ b/src/test/scala/scraml/libs/TapirSupportSpec.scala
@@ -192,8 +192,8 @@ final class TapirSupportSpec
           |  }
           |  object Endpoints {
           |    object Greeting {
-          |      final case class GetGreetingByPreambleAndDelayParams(preamble: Preamble, delay: Option[Int], name: Option[String] = None, repeat: Option[Int] = None, uppercase: Option[Boolean] = None)
-          |      val getGreetingByPreambleAndDelay = endpoint.get.in("greeting" / path[Preamble]("preamble") / path[Option[Int]]("delay")).in(query[Option[String]]("name") and query[Option[Int]]("repeat") and query[Option[Boolean]]("uppercase")).mapInTo[GetGreetingByPreambleAndDelayParams].out(jsonBody[DataType])
+          |      final case class GetGreetingByPreambleAndDelayParams(preamble: Preamble, delay: Int, name: Option[String] = None, repeat: Option[Int] = None, uppercase: Option[Boolean] = None)
+          |      val getGreetingByPreambleAndDelay = endpoint.get.in("greeting" / path[Preamble]("preamble") / path[Int]("delay")).in(query[Option[String]]("name") and query[Option[Int]]("repeat") and query[Option[Boolean]]("uppercase")).mapInTo[GetGreetingByPreambleAndDelayParams].out(jsonBody[DataType])
           |    }
           |  }
           |}""".stripMargin.stripTrailingSpaces


### PR DESCRIPTION
Recommended tag: `v0.12.2`

This PR partially addresses issue #47 along with a defect in scaladoc content generation.  These changes will:

- Generate expected `Params` type names when more than one URI parameter is present.
- Generate expected `Params` variable names when more than one URI parameter is present.
- Use the declared `type`s from `uriParameters`.

What is missing from this PR is `LibrarySupport` for tapir generated parameter types.  This is most interesting for `RefinedSupport`, though other `LilbrarySupport` functionality have value as well.

Since introducing `LibrarySupport` use requires changes beyond what can be incorporated now, this PR is being requested.  A follow-up PR is expected if the remaining functionality can be introduced in a compatible manner.