### PR TITLE
(gen): fix leaf types aggregation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -39,7 +39,7 @@ lazy val root = (project in file("."))
   .enablePlugins(SbtPlugin, ParadoxSitePlugin, GhpagesPlugin)
   .settings(
     name                                          := "sbt-scraml",
-    libraryDependencies += "com.commercetools.rmf" % "raml-model"       % "0.2.0-20211203200453",
+    libraryDependencies += "com.commercetools.rmf" % "raml-model"       % "0.2.0-20220914193841",
     libraryDependencies += "org.scalameta"        %% "scalameta"        % "4.4.20",
     libraryDependencies += "org.scalameta"        %% "scalafmt-dynamic" % "3.0.0-RC6",
     libraryDependencies += "org.typelevel"        %% "cats-effect"      % "3.1.1",

--- a/src/test/resources/scala-extends/ctype.raml
+++ b/src/test/resources/scala-extends/ctype.raml
@@ -8,3 +8,5 @@ discriminatorValue: "C"
 properties:
   id:
     type: string
+  someField:
+    type: E

--- a/src/test/resources/scala-extends/etype.raml
+++ b/src/test/resources/scala-extends/etype.raml
@@ -1,0 +1,9 @@
+#%RAML 1.0 DataType
+(package): DataTypes
+(docs-uri): "https://example.org/E"
+displayName: E
+type: B
+discriminatorValue: "E"
+properties:
+  id:
+    type: string

--- a/src/test/resources/scala-extends/types.raml
+++ b/src/test/resources/scala-extends/types.raml
@@ -1,4 +1,5 @@
 A: !include atype.raml
-B: !include btype.raml
+E: !include etype.raml
 C: !include ctype.raml
+B: !include btype.raml
 D: !include dtype.raml

--- a/src/test/scala/scraml/RMFUtilSpec.scala
+++ b/src/test/scala/scraml/RMFUtilSpec.scala
@@ -34,7 +34,7 @@ class RMFUtilSpec extends AnyFlatSpec with Matchers {
           .map(_.getName) should be(Set("B", "C"))
 
         context.leafTypes
-          .map(_.getName) should be(Set("D"))
+          .map(_.getName) should be(Set("D", "E"))
       case _ => fail("type for test not found")
     }
   }


### PR DESCRIPTION
Currently, in the leaf type aggregation, some intermediate types might end up in the result set because RMF creates subtypes on usages in properties. That is also the reason for the current names filter but it is not sufficient in all cases.
This can lead to unreachable code in the decoders.

I tried to replicate that in our leaf-types spec, but the attempted example is not sufficient to capture this.

With this change, we make sure the types we iterate through are API-level types. As a consequence, we might have some types that were previously intermediate types because they have (only) property subtypes. Those are considered leaf types now if the filtered subtypes set is empty.

this also updates raml-model and related fixes