### PR TITLE
(circe): expose discriminator value via `jsonTypeHint`

### DIFF
--- a/src/main/scala/scraml/FieldMatchPolicy.scala
+++ b/src/main/scala/scraml/FieldMatchPolicy.scala
@@ -23,13 +23,13 @@ sealed trait FieldMatchPolicy {
 
   final def namedProperties(objectType: ObjectType): List[Property] =
     RMFUtil
-      .typeProperties(objectType)
+      .typePropertiesWithoutDiscriminator(objectType)
       .filterNot(isPatternProperty)
       .toList
 
   final def patternProperties(objectType: ObjectType): List[Property] =
     RMFUtil
-      .typeProperties(objectType)
+      .typePropertiesWithoutDiscriminator(objectType)
       .filter(isPatternProperty)
       .toList
 

--- a/src/main/scala/scraml/RMFUtil.scala
+++ b/src/main/scala/scraml/RMFUtil.scala
@@ -105,13 +105,16 @@ object RMFUtil {
         .toList
     }
 
+  def typePropertiesWithoutDiscriminator(objectType: ObjectType): Iterator[Property] =
+    typeProperties(objectType).filter(property =>
+      !discriminators(objectType).contains(property.getName)
+    )
+
   /** get all (including inherited) properties of a type note: will not include properties from
     * 'scala-extends' references
     */
   def typeProperties(objectType: ObjectType): Iterator[Property] =
-    objectType.getAllProperties.asScala.iterator.filter(property =>
-      !discriminators(objectType).contains(property.getName)
-    )
+    objectType.getAllProperties.asScala.iterator
 
   def readModel(apiPath: File): IO[Api] = for {
     model <- IO {

--- a/src/test/scala/scraml/libs/CirceJsonSupportSpec.scala
+++ b/src/test/scala/scraml/libs/CirceJsonSupportSpec.scala
@@ -77,9 +77,9 @@ class CirceJsonSupportSpec extends AnyFlatSpec with Matchers with SourceCodeForm
                                                                       |  import io.circe._
                                                                       |  implicit lazy val decoder: Decoder[BaseType] = new Decoder[BaseType] {
                                                                       |    override def apply(c: HCursor): Result[BaseType] = c.downField("type").as[String] match {
-                                                                      |      case Right("data") =>
+                                                                      |      case Right(DataType.jsonTypeHint) =>
                                                                       |        DataType.decoder(c)
-                                                                      |      case Right("grandchild") =>
+                                                                      |      case Right(GrandchildType.jsonTypeHint) =>
                                                                       |        GrandchildType.decoder(c)
                                                                       |      case other =>
                                                                       |        Left(DecodingFailure(s"unknown discriminator: $$other", c.history))
@@ -112,8 +112,9 @@ class CirceJsonSupportSpec extends AnyFlatSpec with Matchers with SourceCodeForm
                                                                       |  import io.circe.generic.semiauto._
                                                                       |  import io.circe.syntax._
                                                                       |  import scraml.Formats._
+                                                                      |  val jsonTypeHint = "data"
                                                                       |  implicit lazy val decoder: Decoder[DataType] = deriveDecoder[DataType]
-                                                                      |  implicit lazy val encoder: Encoder[DataType] = deriveEncoder[DataType].mapJsonObject(_.+:("type" -> Json.fromString("data")))
+                                                                      |  implicit lazy val encoder: Encoder[DataType] = deriveEncoder[DataType].mapJsonObject(_.+:("type" -> Json.fromString(jsonTypeHint)))
                                                                       |}""".stripMargin.stripTrailingSpaces
           )
         )
@@ -126,7 +127,7 @@ class CirceJsonSupportSpec extends AnyFlatSpec with Matchers with SourceCodeForm
                                                                        |  import io.circe._
                                                                        |  implicit lazy val decoder: Decoder[EmptyBase] = new Decoder[EmptyBase] {
                                                                        |    override def apply(c: HCursor): Result[EmptyBase] = c.downField("type").as[String] match {
-                                                                       |      case Right("nope") =>
+                                                                       |      case Right(NoProps.jsonTypeHint) =>
                                                                        |        NoProps.decoder(c)
                                                                        |      case other =>
                                                                        |        Left(DecodingFailure(s"unknown discriminator: $$other", c.history))
@@ -147,15 +148,16 @@ class CirceJsonSupportSpec extends AnyFlatSpec with Matchers with SourceCodeForm
              |  import io.circe._
              |  import io.circe.generic.semiauto._
              |  import io.circe.Decoder.Result
+             |  val jsonTypeHint = "nope"
              |  implicit lazy val decoder: Decoder[NoProps.type] = new Decoder[NoProps.type] {
              |    override def apply(c: HCursor): Result[NoProps.type] = c.downField("type").as[String] match {
-             |      case Right("nope") =>
+             |      case Right(jsonTypeHint) =>
              |        Right(NoProps)
              |      case other =>
              |        Left(DecodingFailure(s"unknown type: $$other", c.history))
              |    }
              |  }
-             |  implicit lazy val encoder: Encoder[NoProps.type] = new Encoder[NoProps.type] { override def apply(a: NoProps.type): Json = Json.obj("type" -> Json.fromString("nope")) }
+             |  implicit lazy val encoder: Encoder[NoProps.type] = new Encoder[NoProps.type] { override def apply(a: NoProps.type): Json = Json.obj("type" -> Json.fromString(jsonTypeHint)) }
              |}""".stripMargin.stripTrailingSpaces
         )
 
@@ -167,9 +169,9 @@ class CirceJsonSupportSpec extends AnyFlatSpec with Matchers with SourceCodeForm
                                                                           |  import io.circe._
                                                                           |  implicit lazy val decoder: Decoder[NoSealedBase] = new Decoder[NoSealedBase] {
                                                                           |    override def apply(c: HCursor): Result[NoSealedBase] = c.downField("typeId").as[String] match {
-                                                                          |      case Right("map-like") =>
+                                                                          |      case Right(MapLike.jsonTypeHint) =>
                                                                           |        MapLike.decoder(c)
-                                                                          |      case Right("other-sub") =>
+                                                                          |      case Right(OtherSub.jsonTypeHint) =>
                                                                           |        OtherSub.decoder(c)
                                                                           |      case other =>
                                                                           |        Left(DecodingFailure(s"unknown discriminator: $$other", c.history))
@@ -199,6 +201,7 @@ class CirceJsonSupportSpec extends AnyFlatSpec with Matchers with SourceCodeForm
                                                                      |  import io.circe.Decoder.Result
                                                                      |  implicit lazy val decoder: Decoder[MapLike] = new Decoder[MapLike] { override def apply(c: HCursor): Result[MapLike] = c.as[scala.collection.immutable.Map[String, Long]].map(MapLike.apply) }
                                                                      |  implicit lazy val encoder: Encoder[MapLike] = new Encoder[MapLike] { override def apply(a: MapLike): Json = a.values.asJson }
+                                                                     |  val jsonTypeHint = "map-like"
                                                                      |}""".stripMargin.stripTrailingSpaces
           )
         )
@@ -240,8 +243,9 @@ class CirceJsonSupportSpec extends AnyFlatSpec with Matchers with SourceCodeForm
             |  import io.circe.generic.semiauto._
             |  import io.circe.syntax._
             |  import scraml.Formats._
+            |  val jsonTypeHint = "other-sub"
             |  implicit lazy val decoder: Decoder[OtherSub] = deriveDecoder[OtherSub]
-            |  implicit lazy val encoder: Encoder[OtherSub] = deriveEncoder[OtherSub].mapJsonObject(_.+:("typeId" -> Json.fromString("other-sub")))
+            |  implicit lazy val encoder: Encoder[OtherSub] = deriveEncoder[OtherSub].mapJsonObject(_.+:("typeId" -> Json.fromString(jsonTypeHint)))
             |}""".stripMargin.stripTrailingSpaces
           )
         )
@@ -272,7 +276,7 @@ class CirceJsonSupportSpec extends AnyFlatSpec with Matchers with SourceCodeForm
                   |  import io.circe._
                   |  implicit lazy val decoder: Decoder[IntermediateType] = new Decoder[IntermediateType] {
                   |    override def apply(c: HCursor): Result[IntermediateType] = c.downField("type").as[String] match {
-                  |      case Right("grandchild") =>
+                  |      case Right(GrandchildType.jsonTypeHint) =>
                   |        GrandchildType.decoder(c)
                   |      case other =>
                   |        Left(DecodingFailure(s"unknown discriminator: $$other", c.history))
@@ -297,8 +301,9 @@ class CirceJsonSupportSpec extends AnyFlatSpec with Matchers with SourceCodeForm
               |  import io.circe.generic.semiauto._
               |  import io.circe.syntax._
               |  import scraml.Formats._
+              |  val jsonTypeHint = "grandchild"
               |  implicit lazy val decoder: Decoder[GrandchildType] = deriveDecoder[GrandchildType]
-              |  implicit lazy val encoder: Encoder[GrandchildType] = deriveEncoder[GrandchildType].mapJsonObject(_.+:("type" -> Json.fromString("grandchild")))
+              |  implicit lazy val encoder: Encoder[GrandchildType] = deriveEncoder[GrandchildType].mapJsonObject(_.+:("type" -> Json.fromString(jsonTypeHint)))
               |}""".stripMargin.stripTrailingSpaces
           )
         )
@@ -448,9 +453,9 @@ class CirceJsonSupportSpec extends AnyFlatSpec with Matchers with SourceCodeForm
                |  import io.circe._
                |  implicit lazy val decoder: Decoder[BaseType] = new Decoder[BaseType] {
                |    override def apply(c: HCursor): Result[BaseType] = c.downField("type").as[String] match {
-               |      case Right("data") =>
+               |      case Right(DataType.jsonTypeHint) =>
                |        DataType.decoder(c)
-               |      case Right("grandchild") =>
+               |      case Right(GrandchildType.jsonTypeHint) =>
                |        GrandchildType.decoder(c)
                |      case other =>
                |        Left(DecodingFailure(s"unknown discriminator: $other", c.history))
@@ -522,6 +527,7 @@ class CirceJsonSupportSpec extends AnyFlatSpec with Matchers with SourceCodeForm
                  |  import io.circe.generic.semiauto._
                  |  import io.circe.syntax._
                  |  import scraml.Formats._
+                 |  val jsonTypeHint = "data"
                  |  implicit lazy val decoder: Decoder[DataType] = new Decoder[DataType] {
                  |    def apply(c: HCursor): Decoder.Result[DataType] = {
                  |      c.downField("id").as[String].flatMap { (_id: String) =>
@@ -537,7 +543,7 @@ class CirceJsonSupportSpec extends AnyFlatSpec with Matchers with SourceCodeForm
                  |      }
                  |    }
                  |  }
-                 |  implicit lazy val encoder: Encoder[DataType] = new Encoder[DataType] { final def apply(instance: DataType): Json = AdditionalProperties.merge(Json.obj("type" -> Json.fromString("data"), "id" -> instance.id.asJson, "foo" -> instance.foo.asJson, "customTypeProp" -> instance.customTypeProp.asJson, "customArrayTypeProp" -> instance.customArrayTypeProp.asJson), instance.additionalProperties) }
+                 |  implicit lazy val encoder: Encoder[DataType] = new Encoder[DataType] { final def apply(instance: DataType): Json = AdditionalProperties.merge(Json.obj("type" -> Json.fromString(jsonTypeHint), "id" -> instance.id.asJson, "foo" -> instance.foo.asJson, "customTypeProp" -> instance.customTypeProp.asJson, "customArrayTypeProp" -> instance.customArrayTypeProp.asJson), instance.additionalProperties) }
                  |}""".stripMargin.stripTrailingSpaces)
         )
 
@@ -548,7 +554,7 @@ class CirceJsonSupportSpec extends AnyFlatSpec with Matchers with SourceCodeForm
                   |  import io.circe._
                   |  implicit lazy val decoder: Decoder[EmptyBase] = new Decoder[EmptyBase] {
                   |    override def apply(c: HCursor): Result[EmptyBase] = c.downField("type").as[String] match {
-                  |      case Right("nope") =>
+                  |      case Right(NoProps.jsonTypeHint) =>
                   |        NoProps.decoder(c)
                   |      case other =>
                   |        Left(DecodingFailure(s"unknown discriminator: $other", c.history))
@@ -615,6 +621,7 @@ class CirceJsonSupportSpec extends AnyFlatSpec with Matchers with SourceCodeForm
               |  import io.circe.generic.semiauto._
               |  import io.circe.syntax._
               |  import scraml.Formats._
+              |  val jsonTypeHint = "nope"
               |  implicit lazy val decoder: Decoder[NoProps] = new Decoder[NoProps] {
               |    def apply(c: HCursor): Decoder.Result[NoProps] = {
               |      AdditionalProperties.decoder(c).map {
@@ -622,7 +629,7 @@ class CirceJsonSupportSpec extends AnyFlatSpec with Matchers with SourceCodeForm
               |      }
               |    }
               |  }
-              |  implicit lazy val encoder: Encoder[NoProps] = new Encoder[NoProps] { final def apply(instance: NoProps): Json = AdditionalProperties.merge(Json.obj("type" -> Json.fromString("nope")), instance.additionalProperties) }
+              |  implicit lazy val encoder: Encoder[NoProps] = new Encoder[NoProps] { final def apply(instance: NoProps): Json = AdditionalProperties.merge(Json.obj("type" -> Json.fromString(jsonTypeHint)), instance.additionalProperties) }
               |}""".stripMargin.stripTrailingSpaces
           )
         )
@@ -635,9 +642,9 @@ class CirceJsonSupportSpec extends AnyFlatSpec with Matchers with SourceCodeForm
                |  import io.circe._
                |  implicit lazy val decoder: Decoder[NoSealedBase] = new Decoder[NoSealedBase] {
                |    override def apply(c: HCursor): Result[NoSealedBase] = c.downField("typeId").as[String] match {
-               |      case Right("map-like") =>
+               |      case Right(MapLike.jsonTypeHint) =>
                |        MapLike.decoder(c)
-               |      case Right("other-sub") =>
+               |      case Right(OtherSub.jsonTypeHint) =>
                |        OtherSub.decoder(c)
                |      case other =>
                |        Left(DecodingFailure(s"unknown discriminator: $other", c.history))
@@ -667,6 +674,7 @@ class CirceJsonSupportSpec extends AnyFlatSpec with Matchers with SourceCodeForm
               |  import io.circe.Decoder.Result
               |  implicit lazy val decoder: Decoder[MapLike] = new Decoder[MapLike] { override def apply(c: HCursor): Result[MapLike] = c.as[scala.collection.immutable.Map[String, Long]].map(MapLike.apply) }
               |  implicit lazy val encoder: Encoder[MapLike] = new Encoder[MapLike] { override def apply(a: MapLike): Json = a.values.asJson }
+              |  val jsonTypeHint = "map-like"
               |}""".stripMargin.stripTrailingSpaces
           )
         )
@@ -749,6 +757,7 @@ class CirceJsonSupportSpec extends AnyFlatSpec with Matchers with SourceCodeForm
               |  import io.circe.generic.semiauto._
               |  import io.circe.syntax._
               |  import scraml.Formats._
+              |  val jsonTypeHint = "other-sub"
               |  implicit lazy val decoder: Decoder[OtherSub] = new Decoder[OtherSub] {
               |    def apply(c: HCursor): Decoder.Result[OtherSub] = {
               |      c.downField("id").as[String].flatMap { (_id: String) =>
@@ -758,7 +767,7 @@ class CirceJsonSupportSpec extends AnyFlatSpec with Matchers with SourceCodeForm
               |      }
               |    }
               |  }
-              |  implicit lazy val encoder: Encoder[OtherSub] = new Encoder[OtherSub] { final def apply(instance: OtherSub): Json = AdditionalProperties.merge(Json.obj("typeId" -> Json.fromString("other-sub"), "id" -> instance.id.asJson), instance.additionalProperties) }
+              |  implicit lazy val encoder: Encoder[OtherSub] = new Encoder[OtherSub] { final def apply(instance: OtherSub): Json = AdditionalProperties.merge(Json.obj("typeId" -> Json.fromString(jsonTypeHint), "id" -> instance.id.asJson), instance.additionalProperties) }
               |}""".stripMargin.stripTrailingSpaces
           )
         )
@@ -789,7 +798,7 @@ class CirceJsonSupportSpec extends AnyFlatSpec with Matchers with SourceCodeForm
                   |  import io.circe._
                   |  implicit lazy val decoder: Decoder[IntermediateType] = new Decoder[IntermediateType] {
                   |    override def apply(c: HCursor): Result[IntermediateType] = c.downField("type").as[String] match {
-                  |      case Right("grandchild") =>
+                  |      case Right(GrandchildType.jsonTypeHint) =>
                   |        GrandchildType.decoder(c)
                   |      case other =>
                   |        Left(DecodingFailure(s"unknown discriminator: $other", c.history))
@@ -855,6 +864,7 @@ class CirceJsonSupportSpec extends AnyFlatSpec with Matchers with SourceCodeForm
               |  import io.circe.generic.semiauto._
               |  import io.circe.syntax._
               |  import scraml.Formats._
+              |  val jsonTypeHint = "grandchild"
               |  implicit lazy val decoder: Decoder[GrandchildType] = new Decoder[GrandchildType] {
               |    def apply(c: HCursor): Decoder.Result[GrandchildType] = {
               |      c.downField("id").as[String].flatMap { (_id: String) =>
@@ -878,7 +888,7 @@ class CirceJsonSupportSpec extends AnyFlatSpec with Matchers with SourceCodeForm
               |      }
               |    }
               |  }
-              |  implicit lazy val encoder: Encoder[GrandchildType] = new Encoder[GrandchildType] { final def apply(instance: GrandchildType): Json = AdditionalProperties.merge(Json.obj("type" -> Json.fromString("grandchild"), "id" -> instance.id.asJson, "foo" -> instance.foo.asJson, "aDouble" -> instance.aDouble.asJson, "aFloat" -> instance.aFloat.asJson, "anInt" -> instance.anInt.asJson, "aLong" -> instance.aLong.asJson, "customTypeProp" -> instance.customTypeProp.asJson, "customArrayTypeProp" -> instance.customArrayTypeProp.asJson), instance.additionalProperties) }
+              |  implicit lazy val encoder: Encoder[GrandchildType] = new Encoder[GrandchildType] { final def apply(instance: GrandchildType): Json = AdditionalProperties.merge(Json.obj("type" -> Json.fromString(jsonTypeHint), "id" -> instance.id.asJson, "foo" -> instance.foo.asJson, "aDouble" -> instance.aDouble.asJson, "aFloat" -> instance.aFloat.asJson, "anInt" -> instance.anInt.asJson, "aLong" -> instance.aLong.asJson, "customTypeProp" -> instance.customTypeProp.asJson, "customArrayTypeProp" -> instance.customArrayTypeProp.asJson), instance.additionalProperties) }
               |}""".stripMargin.stripTrailingSpaces
           )
         )

--- a/src/test/scala/scraml/libs/RefinedSupportSpec.scala
+++ b/src/test/scala/scraml/libs/RefinedSupportSpec.scala
@@ -46,6 +46,7 @@ class RefinedSupportSpec extends AnyWordSpec with Matchers with SourceCodeFormat
             |  import io.circe._
             |  import io.circe.generic.semiauto._
             |  import io.circe.syntax._
+            |  val jsonTypeHint = "data"
             |  import io.circe.refined._
             |  implicit lazy val decoder: Decoder[DataType] = new Decoder[DataType] {
             |    def apply(c: HCursor): Decoder.Result[DataType] = {
@@ -68,7 +69,7 @@ class RefinedSupportSpec extends AnyWordSpec with Matchers with SourceCodeFormat
             |      }
             |    }
             |  }
-            |  implicit lazy val encoder: Encoder[DataType] = deriveEncoder[DataType].mapJsonObject(_.+:("type" -> Json.fromString("data")))
+            |  implicit lazy val encoder: Encoder[DataType] = deriveEncoder[DataType].mapJsonObject(_.+:("type" -> Json.fromString(jsonTypeHint)))
             |  import eu.timepit.refined.api.Refined
             |  import eu.timepit.refined.boolean.And
             |  import eu.timepit.refined.collection._
@@ -225,7 +226,7 @@ class RefinedSupportSpec extends AnyWordSpec with Matchers with SourceCodeFormat
             |  import io.circe._
             |  implicit lazy val decoder: Decoder[BaseType] = new Decoder[BaseType] {
             |    override def apply(c: HCursor): Result[BaseType] = c.downField("type").as[String] match {
-            |      case Right("data") =>
+            |      case Right(DataType.jsonTypeHint) =>
             |        DataType.decoder(c)
             |      case other =>
             |        Left(DecodingFailure(s"unknown discriminator: $other", c.history))
@@ -288,6 +289,7 @@ class RefinedSupportSpec extends AnyWordSpec with Matchers with SourceCodeFormat
             |  import io.circe._
             |  import io.circe.generic.semiauto._
             |  import io.circe.syntax._
+            |  val jsonTypeHint = "data"
             |  import io.circe.refined._
             |  implicit lazy val decoder: Decoder[DataType] = new Decoder[DataType] {
             |    def apply(c: HCursor): Decoder.Result[DataType] = {
@@ -310,7 +312,7 @@ class RefinedSupportSpec extends AnyWordSpec with Matchers with SourceCodeFormat
             |      }
             |    }
             |  }
-            |  implicit lazy val encoder: Encoder[DataType] = new Encoder[DataType] { final def apply(instance: DataType): Json = Json.obj("type" -> Json.fromString("data"), "id" -> instance.id.asJson, "optionalCustomArrayTypeProp" -> instance.optionalCustomArrayTypeProp.asJson, "foo" -> instance.foo.asJson, "bar" -> instance.bar.asJson, "numberProp" -> instance.numberProp.asJson, "customNumberProp" -> instance.customNumberProp.asJson, "customArrayTypeProp" -> instance.customArrayTypeProp.asJson, "optionalStringArray" -> instance.optionalStringArray.asJson) }
+            |  implicit lazy val encoder: Encoder[DataType] = new Encoder[DataType] { final def apply(instance: DataType): Json = Json.obj("type" -> Json.fromString(jsonTypeHint), "id" -> instance.id.asJson, "optionalCustomArrayTypeProp" -> instance.optionalCustomArrayTypeProp.asJson, "foo" -> instance.foo.asJson, "bar" -> instance.bar.asJson, "numberProp" -> instance.numberProp.asJson, "customNumberProp" -> instance.customNumberProp.asJson, "customArrayTypeProp" -> instance.customArrayTypeProp.asJson, "optionalStringArray" -> instance.optionalStringArray.asJson) }
             |  import eu.timepit.refined.api.Refined
             |  import eu.timepit.refined.boolean.And
             |  import eu.timepit.refined.collection._
@@ -521,6 +523,7 @@ class RefinedSupportSpec extends AnyWordSpec with Matchers with SourceCodeFormat
             |  import io.circe._
             |  import io.circe.generic.semiauto._
             |  import io.circe.syntax._
+            |  val jsonTypeHint = "data"
             |  import io.circe.refined._
             |  implicit lazy val decoder: Decoder[DataType] = new Decoder[DataType] {
             |    def apply(c: HCursor): Decoder.Result[DataType] = {
@@ -545,7 +548,7 @@ class RefinedSupportSpec extends AnyWordSpec with Matchers with SourceCodeFormat
             |      }
             |    }
             |  }
-            |  implicit lazy val encoder: Encoder[DataType] = new Encoder[DataType] { final def apply(instance: DataType): Json = AdditionalProperties.merge(Json.obj("type" -> Json.fromString("data"), "id" -> instance.id.asJson, "optionalCustomArrayTypeProp" -> instance.optionalCustomArrayTypeProp.asJson, "foo" -> instance.foo.asJson, "bar" -> instance.bar.asJson, "numberProp" -> instance.numberProp.asJson, "customNumberProp" -> instance.customNumberProp.asJson, "customArrayTypeProp" -> instance.customArrayTypeProp.asJson, "optionalStringArray" -> instance.optionalStringArray.asJson), instance.additionalProperties) }
+            |  implicit lazy val encoder: Encoder[DataType] = new Encoder[DataType] { final def apply(instance: DataType): Json = AdditionalProperties.merge(Json.obj("type" -> Json.fromString(jsonTypeHint), "id" -> instance.id.asJson, "optionalCustomArrayTypeProp" -> instance.optionalCustomArrayTypeProp.asJson, "foo" -> instance.foo.asJson, "bar" -> instance.bar.asJson, "numberProp" -> instance.numberProp.asJson, "customNumberProp" -> instance.customNumberProp.asJson, "customArrayTypeProp" -> instance.customArrayTypeProp.asJson, "optionalStringArray" -> instance.optionalStringArray.asJson), instance.additionalProperties) }
             |  import eu.timepit.refined.api.Refined
             |  import eu.timepit.refined.boolean.And
             |  import eu.timepit.refined.collection._
@@ -715,6 +718,7 @@ class RefinedSupportSpec extends AnyWordSpec with Matchers with SourceCodeFormat
             |  import io.circe._
             |  import io.circe.generic.semiauto._
             |  import io.circe.syntax._
+            |  val jsonTypeHint = "child"
             |  import io.circe.refined._
             |  implicit lazy val decoder: Decoder[ChildWithFacetsType] = new Decoder[ChildWithFacetsType] {
             |    def apply(c: HCursor): Decoder.Result[ChildWithFacetsType] = {
@@ -723,7 +727,7 @@ class RefinedSupportSpec extends AnyWordSpec with Matchers with SourceCodeFormat
             |      }
             |    }
             |  }
-            |  implicit lazy val encoder: Encoder[ChildWithFacetsType] = deriveEncoder[ChildWithFacetsType].mapJsonObject(_.+:("type" -> Json.fromString("child")))
+            |  implicit lazy val encoder: Encoder[ChildWithFacetsType] = deriveEncoder[ChildWithFacetsType].mapJsonObject(_.+:("type" -> Json.fromString(jsonTypeHint)))
             |  import eu.timepit.refined.api.Refined
             |  import eu.timepit.refined.boolean.And
             |  import eu.timepit.refined.collection._
@@ -914,6 +918,7 @@ class RefinedSupportSpec extends AnyWordSpec with Matchers with SourceCodeFormat
             |  import io.circe._
             |  import io.circe.generic.semiauto._
             |  import io.circe.syntax._
+            |  val jsonTypeHint = "overrides"
             |  import io.circe.refined._
             |  implicit lazy val decoder: Decoder[ChildOverridesAll] = new Decoder[ChildOverridesAll] {
             |    def apply(c: HCursor): Decoder.Result[ChildOverridesAll] = {
@@ -928,7 +933,7 @@ class RefinedSupportSpec extends AnyWordSpec with Matchers with SourceCodeFormat
             |      }
             |    }
             |  }
-            |  implicit lazy val encoder: Encoder[ChildOverridesAll] = deriveEncoder[ChildOverridesAll].mapJsonObject(_.+:("type" -> Json.fromString("overrides")))
+            |  implicit lazy val encoder: Encoder[ChildOverridesAll] = deriveEncoder[ChildOverridesAll].mapJsonObject(_.+:("type" -> Json.fromString(jsonTypeHint)))
             |  import eu.timepit.refined.api.Refined
             |  import eu.timepit.refined.boolean.And
             |  import eu.timepit.refined.collection._
@@ -1048,6 +1053,7 @@ class RefinedSupportSpec extends AnyWordSpec with Matchers with SourceCodeFormat
             |  import io.circe._
             |  import io.circe.generic.semiauto._
             |  import io.circe.syntax._
+            |  val jsonTypeHint = "inherited"
             |  import io.circe.refined._
             |  implicit lazy val decoder: Decoder[ChildInheritsAll] = new Decoder[ChildInheritsAll] {
             |    def apply(c: HCursor): Decoder.Result[ChildInheritsAll] = {
@@ -1062,7 +1068,7 @@ class RefinedSupportSpec extends AnyWordSpec with Matchers with SourceCodeFormat
             |      }
             |    }
             |  }
-            |  implicit lazy val encoder: Encoder[ChildInheritsAll] = deriveEncoder[ChildInheritsAll].mapJsonObject(_.+:("type" -> Json.fromString("inherited")))
+            |  implicit lazy val encoder: Encoder[ChildInheritsAll] = deriveEncoder[ChildInheritsAll].mapJsonObject(_.+:("type" -> Json.fromString(jsonTypeHint)))
             |  import eu.timepit.refined.api.Refined
             |  import eu.timepit.refined.boolean.And
             |  import eu.timepit.refined.collection._


### PR DESCRIPTION
this adds a `jsonTypeHint` value to the companion object if circe lib support is used 
the same field is then used in the to add/read the value during serialization, removing some redundancy