### PR TITLE
Using lazy val to prevent method too large errors

### DIFF
--- a/src/main/scala/scraml/libs/TapirSupport.scala
+++ b/src/main/scala/scraml/libs/TapirSupport.scala
@@ -275,7 +275,7 @@ final class TapirSupport(endpointsObjectName: String) extends LibrarySupport {
 
       val endpointValueDef: Defn.Val =
         q"""
-          val ${Pat.Var(Term.Name(resourceMethodName))} = $endpointWithErrorOut
+          lazy val ${Pat.Var(Term.Name(resourceMethodName))} = $endpointWithErrorOut
         """
 
       List(

--- a/src/test/scala/scraml/libs/TapirSupportSpec.scala
+++ b/src/test/scala/scraml/libs/TapirSupportSpec.scala
@@ -75,7 +75,7 @@ final class TapirSupportSpec
         |  object Endpoints {
         |    object Greeting {
         |      final case class GetGreetingParams(enum_type: SomeEnum, name: Option[String] = None)
-        |      val getGreeting = endpoint.get.in("greeting").in(query[SomeEnum]("enum_type") and query[Option[String]]("name")).mapInTo[GetGreetingParams].out(jsonBody[DataType])
+        |      lazy val getGreeting = endpoint.get.in("greeting").in(query[SomeEnum]("enum_type") and query[Option[String]]("name")).mapInTo[GetGreetingParams].out(jsonBody[DataType])
         |    }
         |  }
         |}""".stripMargin
@@ -193,7 +193,7 @@ final class TapirSupportSpec
           |  object Endpoints {
           |    object Greeting {
           |      final case class GetGreetingByPreambleAndDelayParams(preamble: Preamble, delay: Int, name: Option[String] = None, repeat: Option[Int] = None, uppercase: Option[Boolean] = None)
-          |      val getGreetingByPreambleAndDelay = endpoint.get.in("greeting" / path[Preamble]("preamble") / path[Int]("delay")).in(query[Option[String]]("name") and query[Option[Int]]("repeat") and query[Option[Boolean]]("uppercase")).mapInTo[GetGreetingByPreambleAndDelayParams].out(jsonBody[DataType])
+          |      lazy val getGreetingByPreambleAndDelay = endpoint.get.in("greeting" / path[Preamble]("preamble") / path[Int]("delay")).in(query[Option[String]]("name") and query[Option[Int]]("repeat") and query[Option[Boolean]]("uppercase")).mapInTo[GetGreetingByPreambleAndDelayParams].out(jsonBody[DataType])
           |    }
           |  }
           |}""".stripMargin.stripTrailingSpaces


### PR DESCRIPTION
Discovered during the custom fields implementation https://commercetools.atlassian.net/browse/CUT-1279

Slack context: https://commercetools.slack.com/archives/C02EAJSD189/p1721038197789089
Error: 
![image](https://github.com/user-attachments/assets/383339c2-0f51-4a6e-97a4-0e05e8c10d9a)

Tapir issue https://github.com/softwaremill/tapir/issues/232