### PR TITLE
Add key based discriminator annotation

### DIFF
--- a/src/sbt-test/sbt-scraml/json/api/annotations.raml
+++ b/src/sbt-test/sbt-scraml/json/api/annotations.raml
@@ -16,3 +16,6 @@ scala-extends:
   type: string
 scala-derive-json:
   type: boolean
+key-base-discriminator:
+  type: string
+

--- a/src/sbt-test/sbt-scraml/json/api/keybasediscriminator.raml
+++ b/src/sbt-test/sbt-scraml/json/api/keybasediscriminator.raml
@@ -1,0 +1,8 @@
+#%RAML 1.0 DataType
+(package): DataTypes
+(docs-uri): "https://example.org/key-base-type"
+displayName: KeyBaseDiscriminator
+type: object
+(scala-derive-json): true
+(key-base-discriminator):
+properties:

--- a/src/sbt-test/sbt-scraml/json/api/keybaseprefixint.raml
+++ b/src/sbt-test/sbt-scraml/json/api/keybaseprefixint.raml
@@ -1,0 +1,11 @@
+#%RAML 1.0 DataType
+(package): KeyBasedTypes
+(docs-uri): "https://example.org/key-base-type"
+displayName: KeyBasePrefixInt
+type: KeyBaseDiscriminator
+(scala-derive-json): true
+(key-base-discriminator): prefix
+properties:
+  prefix:
+    type: number
+    format: int64

--- a/src/sbt-test/sbt-scraml/json/api/keybaseprefixstring.raml
+++ b/src/sbt-test/sbt-scraml/json/api/keybaseprefixstring.raml
@@ -1,0 +1,10 @@
+#%RAML 1.0 DataType
+(package): KeyBasedTypes
+(docs-uri): "https://example.org/key-base-type"
+displayName: KeyBasePrefixString
+type: KeyBaseDiscriminator
+(scala-derive-json): true
+(key-base-discriminator): prefix
+properties:
+  prefix:
+    type: string

--- a/src/sbt-test/sbt-scraml/json/api/keybasewildcard.raml
+++ b/src/sbt-test/sbt-scraml/json/api/keybasewildcard.raml
@@ -1,0 +1,10 @@
+#%RAML 1.0 DataType
+(package): DataTypes
+(docs-uri): "https://example.org/key-base-type"
+displayName: KeyBaseWildcard
+type: KeyBaseDiscriminator
+(scala-derive-json): true
+(key-base-discriminator): wildcard
+properties:
+  wildcard:
+    type: string

--- a/src/sbt-test/sbt-scraml/json/api/types.raml
+++ b/src/sbt-test/sbt-scraml/json/api/types.raml
@@ -15,4 +15,8 @@ DefaultProperty: !include defaultproperty.raml
 ConstrainedString: !include constrainedstring.raml
 ParentWithOption: !include parentwithoption.raml
 DerivedWithRequired: !include derivedwithrequired.raml
+KeyBaseDiscriminator: !include keybasediscriminator.raml
+KeyBaseWildcard: !include keybasewildcard.raml
+KeyBasePrefixString: !include keybaseprefixstring.raml
+KeyBasePrefixInt: !include keybaseprefixint.raml
 


### PR DESCRIPTION
WHY
We need a way to handle error better when deriving a `circe` Json object.
When we decode a sealed trait type, circe decoder is a chain function which does not care about context.
Basically is something like `tryDecode(type1).orElseTryDecode(type2).orElse(throw cannot decode base type)`.
This way we do not know the root decoding failure cause.
HOW
We introduced a `key-base-discriminator` annotation, and the derivation is now slightly changed as e.g.
```
implicit lazy val decoder: Decoder[KeyBaseDiscriminator] = new Decoder[KeyBaseDiscriminator] {
    override def apply(c: HCursor): Result[KeyBaseDiscriminator] = c.value.asObject.toRight(DecodingFailure("expected object", c.history)).flatMap { obj =>
      val keySet = obj.keys.toSet
      keySet match {
        case _ if keySet.contains(wildcard) =>
          KeyBaseWildcard.decoder.tryDecode(c)
        case _ if keySet.contains(prefix) =>
          KeyBasePrefixString.decoder.tryDecode(c).orElse(KeyBasePrefixInt.decoder.tryDecode(c))
      }
    }
  }
```

The annotation example:
```#%RAML 1.0 DataType
(package): KeyBasedTypes
(docs-uri): "https://example.org/key-base-type"
displayName: KeyBasePrefixString
type: KeyBaseDiscriminator
(scala-derive-json): true
(key-base-discriminator): prefix
properties:
  prefix:
    type: string