### PR TITLE
Use default match case for discriminator map

### DIFF
--- a/src/main/scala/scraml/libs/CirceJsonSupport.scala
+++ b/src/main/scala/scraml/libs/CirceJsonSupport.scala
@@ -379,7 +379,33 @@ class CirceJsonSupport(formats: Map[String, String]) extends LibrarySupport with
               fromObjectTypes(context, typeName, keys)
             }
           )
-        }.toList,
+        }.toList ++ List(
+          Case(
+            pat = Pat.Var(Term.Name("other")),
+            cond = Option.empty[Term],
+            body = Term.Apply(
+              Term.Name("Left"),
+              List(
+                Term.Apply(
+                  Term.Name("DecodingFailure"),
+                  List(
+                    Term.Interpolate(
+                      Term.Name("s"),
+                      List(Lit.String("unknown discriminator: "), Lit.String("")),
+                      List(
+                        Term.Apply(
+                        fun =
+                          Term.Select(Term.Select(Term.Select(Term.Name("other"), Term.Name("keys")), Term.Name("headOption")), Term.Name("getOrElse")),
+                        args = List(Lit.String("unknown_value"))
+                        )
+                        )
+                    ),
+                    Term.Select(Term.Name("c"), Term.Name("history"))
+                  )
+                )
+              )
+            )
+          )),
         Nil
       )
     )

--- a/src/main/scala/scraml/libs/CirceJsonSupport.scala
+++ b/src/main/scala/scraml/libs/CirceJsonSupport.scala
@@ -394,18 +394,24 @@ class CirceJsonSupport(formats: Map[String, String]) extends LibrarySupport with
                       List(Lit.String("unknown discriminator: "), Lit.String("")),
                       List(
                         Term.Apply(
-                        fun =
-                          Term.Select(Term.Select(Term.Select(Term.Name("other"), Term.Name("keys")), Term.Name("headOption")), Term.Name("getOrElse")),
-                        args = List(Lit.String("unknown_value"))
+                          fun = Term.Select(
+                            Term.Select(
+                              Term.Select(Term.Name("other"), Term.Name("keys")),
+                              Term.Name("headOption")
+                            ),
+                            Term.Name("getOrElse")
+                          ),
+                          args = List(Lit.String("unknown_value"))
                         )
-                        )
+                      )
                     ),
                     Term.Select(Term.Name("c"), Term.Name("history"))
                   )
                 )
               )
             )
-          )),
+          )
+        ),
         Nil
       )
     )

--- a/src/test/scala/scraml/libs/CirceJsonSupportSpec.scala
+++ b/src/test/scala/scraml/libs/CirceJsonSupportSpec.scala
@@ -400,6 +400,8 @@ class CirceJsonSupportSpec extends AnyFlatSpec with Matchers with SourceCodeForm
                  |          KeyBasePrefixString.decoder.tryDecode(c).fold(_ => KeyBasePrefixInt.decoder.tryDecode(c), Right(_))
                  |        case _ if obj.contains("wildcard") =>
                  |          KeyBaseWildcard.decoder.tryDecode(c)
+                 |        case other =>
+                 |          Left(DecodingFailure(s"unknown discriminator: ${other.keys.headOption.getOrElse("unknown_value")}", c.history))
                  |      }
                  |    }
                  |  }


### PR DESCRIPTION
We overlooked the generic case when mapping `keys` from discriminator.
  ```
implicit lazy val decoder: Decoder[KeyBaseDiscriminator] = new Decoder[KeyBaseDiscriminator] {
    override def apply(c: HCursor): Result[KeyBaseDiscriminator] = c.value.asObject.toRight(DecodingFailure("Expected object", c.history)).flatMap { obj =>
      obj match {
        case _ if obj.contains("prefix") =>
          KeyBasePrefixString.decoder.tryDecode(c).fold(_ => KeyBasePrefixInt.decoder.tryDecode(c), Right(_))
        case _ if obj.contains("wildcard") =>
          KeyBaseWildcard.decoder.tryDecode(c)
       //we also need a generic case
        case other =>
          Left(DecodingFailure(s"unknown discriminator: ${other.keys.headOption.getOrElse("unknown_value")}", c.history))
      }
    }
  }
```