### PR TITLE
fallback to raw binary if no other input type is recognized

### DIFF
--- a/src/main/scala/scraml/libs/TapirSupport.scala
+++ b/src/main/scala/scraml/libs/TapirSupport.scala
@@ -221,7 +221,7 @@ final class TapirSupport(endpointsObjectName: String) extends LibrarySupport {
                """
             case _ =>
               q"""
-                  rawBinaryBody[Any]
+                 inputStreamBody
                """
           }
 

--- a/src/main/scala/scraml/libs/TapirSupport.scala
+++ b/src/main/scala/scraml/libs/TapirSupport.scala
@@ -219,8 +219,10 @@ final class TapirSupport(endpointsObjectName: String) extends LibrarySupport {
               q"""
                  jsonBody[${context.anyTypeName}]
                """
-            case other =>
-              throw new IllegalArgumentException(s"unsupported input media type: $other")
+            case _ =>
+              q"""
+                  rawBinaryBody[Any]
+               """
           }
 
           q"""

--- a/src/sbt-test/sbt-scraml/tapir/api/tapir-complex.raml
+++ b/src/sbt-test/sbt-scraml/tapir/api/tapir-complex.raml
@@ -21,6 +21,7 @@ types: !include types.raml
     preamble:
       description: Discrete selector for text to prefix greeting.
       type: Preamble
+
   get: # HTTP method declaration
     queryParameters:
       name?:
@@ -35,3 +36,7 @@ types: !include types.raml
       200: # HTTP status code
         body: # declare content of response
           type: DataType
+/upload:
+  post:
+    body:
+      image/png:

--- a/src/test/scala/scraml/libs/TapirSupportSpec.scala
+++ b/src/test/scala/scraml/libs/TapirSupportSpec.scala
@@ -249,7 +249,7 @@ final class TapirSupportSpec
           |      final case class GetGreetingByPreambleAndDelayParams(preamble: Preamble, delay: Int, name: Option[String] = None, repeat: Option[Int] = None, uppercase: Option[Boolean] = None)
           |      lazy val getGreetingByPreambleAndDelay = endpoint.get.in("greeting" / path[Preamble]("preamble") / path[Int]("delay")).in(query[Option[String]]("name") and query[Option[Int]]("repeat") and query[Option[Boolean]]("uppercase")).mapInTo[GetGreetingByPreambleAndDelayParams].out(jsonBody[DataType])
           |    }
-          |    object Upload { lazy val postUpload = endpoint.post.in("upload").in(rawBinaryBody[Any]) }
+          |    object Upload { lazy val postUpload = endpoint.post.in("upload").in(inputStreamBody) }
           |  }
           |}""".stripMargin.stripTrailingSpaces
       )

--- a/src/test/scala/scraml/libs/TapirSupportSpec.scala
+++ b/src/test/scala/scraml/libs/TapirSupportSpec.scala
@@ -249,6 +249,7 @@ final class TapirSupportSpec
           |      final case class GetGreetingByPreambleAndDelayParams(preamble: Preamble, delay: Int, name: Option[String] = None, repeat: Option[Int] = None, uppercase: Option[Boolean] = None)
           |      lazy val getGreetingByPreambleAndDelay = endpoint.get.in("greeting" / path[Preamble]("preamble") / path[Int]("delay")).in(query[Option[String]]("name") and query[Option[Int]]("repeat") and query[Option[Boolean]]("uppercase")).mapInTo[GetGreetingByPreambleAndDelayParams].out(jsonBody[DataType])
           |    }
+          |    object Upload { lazy val postUpload = endpoint.post.in("upload").in(rawBinaryBody[Any]) }
           |  }
           |}""".stripMargin.stripTrailingSpaces
       )


### PR DESCRIPTION
this prevents generator errors for APIs with binary input types