### PR TITLE
Improve support for Scala 3 code generation through Scalameta dialects  

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -53,8 +53,8 @@ lazy val root = (project in file("."))
   .settings(
     name                                          := "sbt-scraml",
     libraryDependencies += "com.commercetools.rmf" % "raml-model"       % "0.2.0-20240722205528",
-    libraryDependencies += "org.scalameta"        %% "scalameta"        % "4.12.6",
-    libraryDependencies += "org.scalameta"        %% "scalafmt-dynamic" % "3.8.5",
+    libraryDependencies += "org.scalameta"        %% "scalameta"        % "4.12.7",
+    libraryDependencies += "org.scalameta"        %% "scalafmt-dynamic" % "3.8.6",
     libraryDependencies += "org.typelevel"        %% "cats-effect"      % "3.5.7",
     libraryDependencies += "org.scalatest"        %% "scalatest"        % "3.2.19" % Test,
     libraryDependencies ++= Seq(

--- a/examples/build.sbt
+++ b/examples/build.sbt
@@ -1,6 +1,6 @@
 scalaVersion := "3.3.4"
 
-val circeVersion = "0.14.7"
+val circeVersion = "0.14.10"
 val tapirVersion = "1.11.9"
 
 lazy val examples = (project in file("."))

--- a/src/main/scala/scraml/ModelGen.scala
+++ b/src/main/scala/scraml/ModelGen.scala
@@ -58,7 +58,7 @@ final case class ModelGenParams(
     case Some((2, 12)) => dialects.Scala212
     case Some((2, 13)) => dialects.Scala213
     case Some((3, _))  => dialects.Scala3
-    case _          => dialects.Scala213
+    case _             => dialects.Scala213
   }
 }
 
@@ -440,7 +440,9 @@ object LibrarySupport {
       lib.modifyEnum(enumType, params)(acc.defn, acc.companion)
     }
 
-  def appendObjectStats(defn: Defn.Object, stats: List[Stat])(implicit dialect: Dialect): Defn.Object = {
+  def appendObjectStats(defn: Defn.Object, stats: List[Stat])(implicit
+      dialect: Dialect
+  ): Defn.Object = {
     // copy on Defn.Object and on Template.Body loses dialect information, so we're building them manually,
     // even though we currently don't rely on dialects while building the tree
     Defn.Object(

--- a/src/main/scala/scraml/ScramlPlugin.scala
+++ b/src/main/scala/scraml/ScramlPlugin.scala
@@ -82,7 +82,7 @@ object ScramlPlugin extends AutoPlugin {
             CrossVersion.partialVersion(scalaVersion.value),
             s.log
           )
-
+          s.log.info(s"generating API model targeting Scala ${scalaVersion.value}")
           val generated = ModelGenRunner.run(DefaultModelGen)(params).unsafeRunSync()
 
           s.log.info(s"generated API model for ${definition.raml} in $targetDir")

--- a/src/main/scala/scraml/libs/CirceJsonSupport.scala
+++ b/src/main/scala/scraml/libs/CirceJsonSupport.scala
@@ -648,7 +648,7 @@ class CirceJsonSupport(formats: Map[String, String], imports: Seq[String])
           propertyType match {
             case Some(stringEnum: StringType) if isEnumType(stringEnum) =>
               val enumType     = Term.Name(stringEnum.getName)
-              val enumInstance = Term.Name(stringEnum.getDefault.getValue.toString.toUpperCase)
+              val enumInstance = Term.Name(stringEnum.getDefault.getValue.toString)
 
               if (isRequired)
                 Option(q"$enumType.$enumInstance")
@@ -1080,7 +1080,7 @@ class CirceJsonSupport(formats: Map[String, String], imports: Seq[String])
                     None,
                     Term.Apply(
                       Term.Name("Right"),
-                      Term.ArgClause(List(Term.Name(instance.getValue.toString.toUpperCase)))
+                      Term.ArgClause(List(Term.Name(instance.getValue.toString)))
                     )
                   )
                 )
@@ -1141,7 +1141,7 @@ class CirceJsonSupport(formats: Map[String, String], imports: Seq[String])
               enumType.getEnum.asScala
                 .map(instance =>
                   Case(
-                    Term.Name(instance.getValue.toString.toUpperCase),
+                    Term.Name(instance.getValue.toString),
                     None,
                     Lit.String(instance.getValue.toString)
                   )
@@ -1171,6 +1171,6 @@ class CirceJsonSupport(formats: Map[String, String], imports: Seq[String])
         $enumDecode
        """.stats
 
-    DefnWithCompanion(enumTrait, companion.map(appendObjectStats(_, stats)))
+    DefnWithCompanion(enumTrait, companion.map(appendObjectStats(_, stats)(params.dialect)))
   }
 }

--- a/src/main/scala/scraml/libs/RefinedSupport.scala
+++ b/src/main/scala/scraml/libs/RefinedSupport.scala
@@ -166,9 +166,9 @@ object RefinedSupport extends LibrarySupport {
         max: Option[BigDecimal]
     ): List[Type.Apply] = {
       def toLiteral(number: BigDecimal): Lit = number match {
-        case n if n.isValidInt => Lit.Int(number.toInt)
+        case n if n.isValidInt  => Lit.Int(number.toInt)
         case n if n.isValidLong => Lit.Long(number.toInt)
-        case n => Lit.Double(n.toDouble)
+        case n                  => Lit.Double(n.toDouble)
       }
       (min, max) match {
         case (Some(lower), Some(upper)) if upper < lower =>

--- a/src/main/scala/scraml/libs/SphereJsonSupport.scala
+++ b/src/main/scala/scraml/libs/SphereJsonSupport.scala
@@ -169,7 +169,7 @@ object SphereJsonSupport extends LibrarySupport with JsonSupport {
           Case(
             Lit.String(instance.getValue().toString()),
             None,
-            Term.Select(Term.Name(instance.getValue().toString().toUpperCase()), Term.Name("valid"))
+            Term.Select(Term.Name(instance.getValue().toString()), Term.Name("valid"))
           )
         )
         .toList ++ List(other)

--- a/src/main/scala/scraml/libs/TapirSupport.scala
+++ b/src/main/scala/scraml/libs/TapirSupport.scala
@@ -403,7 +403,7 @@ final class TapirSupport(endpointsObjectName: String) extends LibrarySupport {
           Case(
             Lit.String(enum.getValue.toString),
             None,
-            q"sttp.tapir.DecodeResult.Value(${Term.Name(enum.getValue.toString.toUpperCase())})"
+            q"sttp.tapir.DecodeResult.Value(${Term.Name(enum.getValue.toString)})"
           )
         }
           ++
@@ -440,7 +440,7 @@ final class TapirSupport(endpointsObjectName: String) extends LibrarySupport {
         ${Term.PartialFunction(
         enumNames.map { enum =>
           Case(
-            Term.Name(enum.toUpperCase),
+            Term.Name(enum),
             None,
             Lit.String(enum)
           )

--- a/src/sbt-test/sbt-scraml/cats/build.sbt
+++ b/src/sbt-test/sbt-scraml/cats/build.sbt
@@ -1,6 +1,7 @@
 lazy val root = (project in file("."))
   .settings(
-    scalaVersion := "2.13.15",
+    scalaVersion := "2.13.16",
+    crossScalaVersions ++= Seq("3.3.4"),
     name := "scraml-cats-test",
     version := "0.1",
     ramlFile := Some(file("api/simple.raml")),

--- a/src/sbt-test/sbt-scraml/cats/project/build.properties
+++ b/src/sbt-test/sbt-scraml/cats/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.10.5
+sbt.version = 1.10.7

--- a/src/sbt-test/sbt-scraml/cats/test
+++ b/src/sbt-test/sbt-scraml/cats/test
@@ -2,3 +2,8 @@
 # make sure the expected output is present
 $ exists target/scala-2.13/src_managed/main/scraml/datatypes.scala
 $ exists target/scala-2.13/src_managed/main/scraml/package.scala
+> clean
+> ++3.3
+> compile
+$ exists target/scala-3.3.4/src_managed/main/scraml/datatypes.scala
+$ exists target/scala-3.3.4/src_managed/main/scraml/package.scala

--- a/src/sbt-test/sbt-scraml/ct-api-sphere/build.sbt
+++ b/src/sbt-test/sbt-scraml/ct-api-sphere/build.sbt
@@ -1,8 +1,8 @@
-val circeVersion = "0.14.1"
+val circeVersion = "0.14.10"
 
 lazy val root = (project in file("."))
   .settings(
-    scalaVersion := "2.13.15",
+    scalaVersion := "2.13.16",
     name := "scraml-ct-api-sphere-test",
     version := "0.1",
     ramlFile := Some(file("reference/api-specs/api/api.raml")),

--- a/src/sbt-test/sbt-scraml/ct-api-sphere/project/build.properties
+++ b/src/sbt-test/sbt-scraml/ct-api-sphere/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.10.5
+sbt.version = 1.10.7

--- a/src/sbt-test/sbt-scraml/ct-api/build.sbt
+++ b/src/sbt-test/sbt-scraml/ct-api/build.sbt
@@ -1,11 +1,12 @@
-val circeVersion = "0.14.2"
+val circeVersion = "0.14.10"
 val monocleVersion = "3.1.0"
-val refinedVersion = "0.9.27"
-val tapirVersion = "1.1.0"
+val refinedVersion = "0.11.3"
+val tapirVersion = "1.11.9"
 
 lazy val root = (project in file("."))
   .settings(
-    scalaVersion := "2.13.15",
+    scalaVersion := "2.13.16",
+    crossScalaVersions ++= Seq("3.3.4"),
     name := "scraml-ct-api-circe-test",
     version := "0.1",
     ramlFile := Some(file("reference/api-specs/api/api.raml")),
@@ -24,7 +25,6 @@ lazy val root = (project in file("."))
       scraml.libs.RefinedSupport
     ),
     Compile / sourceGenerators += runScraml,
-    libraryDependencies += "com.chuusai" %% "shapeless" % "2.3.7",
     libraryDependencies ++= Seq(
       "eu.timepit" %% "refined",
       "eu.timepit" %% "refined-cats"
@@ -32,9 +32,9 @@ lazy val root = (project in file("."))
     libraryDependencies ++= Seq(
         "io.circe" %% "circe-core",
         "io.circe" %% "circe-generic",
-        "io.circe" %% "circe-parser",
-        "io.circe" %% "circe-refined"
+        "io.circe" %% "circe-parser"
     ).map(_ % circeVersion),
+    libraryDependencies += "io.circe" %% "circe-refined" % "0.15.1",
     libraryDependencies ++= Seq(
       "dev.optics" %% "monocle-core",
       "dev.optics" %% "monocle-macro"

--- a/src/sbt-test/sbt-scraml/ct-api/project/build.properties
+++ b/src/sbt-test/sbt-scraml/ct-api/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.10.5
+sbt.version = 1.10.7

--- a/src/sbt-test/sbt-scraml/ct-api/test
+++ b/src/sbt-test/sbt-scraml/ct-api/test
@@ -1,1 +1,4 @@
 > compile
+> clean
+> ++3.3
+> compile

--- a/src/sbt-test/sbt-scraml/json/build.sbt
+++ b/src/sbt-test/sbt-scraml/json/build.sbt
@@ -1,19 +1,23 @@
-val circeVersion = "0.14.2"
+val circeVersion = "0.14.10"
 
 lazy val root = (project in file("."))
   .settings(
     name := "scraml-json-test",
-    scalaVersion := "2.13.15",
+    scalaVersion := "2.13.16",
+    crossScalaVersions ++= Seq("3.3.4"),
     version := "0.1",
     ramlFile := Some(file("api/json.raml")),
     basePackageName := "scraml",
     librarySupport := Set(scraml.libs.CirceJsonSupport(
-      formats = Map("localDateTime" -> "io.circe.Decoder.decodeLocalDateTime"),
+      // formats = Map("localDateTime" -> "io.circe.Decoder.decodeLocalDateTime"),
       imports = Seq("io.circe.Decoder.decodeLocalDateTime") // alternative to formats to provide custom codecs via import
     )),
     defaultEnumVariant := Some("Unknown"),
     Compile / sourceGenerators += runScraml,
-    libraryDependencies += "com.commercetools" %% "sphere-json" % "0.12.5",
+    libraryDependencies ++= (CrossVersion.partialVersion(scalaVersion.value) match {
+      case Some((2, 13)) => Seq("com.commercetools" %% "sphere-json" % "0.12.5")
+      case _             => Seq()
+    }),
     libraryDependencies ++= Seq(
         "io.circe" %% "circe-core",
         "io.circe" %% "circe-generic",

--- a/src/sbt-test/sbt-scraml/json/project/build.properties
+++ b/src/sbt-test/sbt-scraml/json/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.10.5
+sbt.version = 1.10.7

--- a/src/sbt-test/sbt-scraml/json/test
+++ b/src/sbt-test/sbt-scraml/json/test
@@ -2,3 +2,9 @@
 $ exists target/scala-2.13/src_managed/main/scraml/datatypes.scala
 $ exists target/scala-2.13/src_managed/main/scraml/package.scala
 > run
+> clean
+> ++3.3
+> compile
+$ exists target/scala-3.3.4/src_managed/main/scraml/datatypes.scala
+$ exists target/scala-3.3.4/src_managed/main/scraml/package.scala
+> run

--- a/src/sbt-test/sbt-scraml/refined/build.sbt
+++ b/src/sbt-test/sbt-scraml/refined/build.sbt
@@ -1,11 +1,12 @@
 import scraml.FieldMatchPolicy._
 
-val circeVersion = "0.14.1"
-val refinedVersion = "0.9.27"
+val circeVersion = "0.14.10"
+val refinedVersion = "0.11.3"
 
 lazy val root = (project in file("."))
   .settings(
-    scalaVersion := "2.13.15",
+    scalaVersion := "2.13.16",
+    crossScalaVersions ++= Seq("3.3.4"),
     name := "scraml-refined-test",
     version := "0.1",
     ramlFile := Some(file("api/refined.raml")),
@@ -41,15 +42,10 @@ lazy val root = (project in file("."))
     librarySupport := Set(
       scraml.libs.CatsEqSupport,
       scraml.libs.CatsShowSupport,
-      scraml.libs.CirceJsonSupport(
-        formats = Map(
-          "localDateTime" -> "io.circe.Decoder.decodeLocalDateTime"
-        )
-      ),
+      scraml.libs.CirceJsonSupport(imports = Seq("io.circe.Decoder.decodeLocalDateTime")),
       scraml.libs.RefinedSupport
     ),
     Compile / sourceGenerators += runScraml,
-    libraryDependencies += "com.chuusai" %% "shapeless" % "2.3.7",
     libraryDependencies ++= Seq(
       "eu.timepit" %% "refined",
       "eu.timepit" %% "refined-cats"
@@ -57,8 +53,8 @@ lazy val root = (project in file("."))
     libraryDependencies ++= Seq(
         "io.circe" %% "circe-core",
         "io.circe" %% "circe-generic",
-        "io.circe" %% "circe-parser",
-        "io.circe" %% "circe-refined"
-    ).map(_ % circeVersion)
+        "io.circe" %% "circe-parser"
+    ).map(_ % circeVersion),
+    libraryDependencies += "io.circe" %% "circe-refined" % "0.15.1",
   )
 

--- a/src/sbt-test/sbt-scraml/refined/project/build.properties
+++ b/src/sbt-test/sbt-scraml/refined/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.10.5
+sbt.version = 1.10.7

--- a/src/sbt-test/sbt-scraml/refined/test
+++ b/src/sbt-test/sbt-scraml/refined/test
@@ -2,3 +2,9 @@
 $ exists target/scala-2.13/src_managed/main/scraml/datatypes.scala
 $ exists target/scala-2.13/src_managed/main/scraml/package.scala
 > run
+> clean
+> ++3.3
+> compile
+$ exists target/scala-3.3.4/src_managed/main/scraml/datatypes.scala
+$ exists target/scala-3.3.4/src_managed/main/scraml/package.scala
+> run

--- a/src/sbt-test/sbt-scraml/simple/build.sbt
+++ b/src/sbt-test/sbt-scraml/simple/build.sbt
@@ -1,5 +1,7 @@
 lazy val root = (project in file("."))
   .settings(
+    scalaVersion := "2.13.16",
+    crossScalaVersions ++= Seq("3.3.4"),
     name := "scraml-simple-test",
     version := "0.1",
     ramlFile := Some(file("api/simple.raml")),

--- a/src/sbt-test/sbt-scraml/simple/project/build.properties
+++ b/src/sbt-test/sbt-scraml/simple/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.10.5
+sbt.version = 1.10.7

--- a/src/sbt-test/sbt-scraml/simple/test
+++ b/src/sbt-test/sbt-scraml/simple/test
@@ -1,3 +1,6 @@
 > compile
 # compile again, should not yield errors
 > compile
+> clean
+> ++3.3
+> compile

--- a/src/sbt-test/sbt-scraml/tapir/build.sbt
+++ b/src/sbt-test/sbt-scraml/tapir/build.sbt
@@ -1,10 +1,11 @@
-val circeVersion = "0.14.7"
-val refinedVersion = "0.11.1"
-val tapirVersion = "1.10.7"
+val circeVersion = "0.14.10"
+val refinedVersion = "0.11.3"
+val tapirVersion = "1.11.9"
 
 lazy val root = (project in file("."))
   .settings(
-    scalaVersion := "2.13.15",
+    scalaVersion := "2.13.16",
+    crossScalaVersions ++= Seq("3.3.4"),
     name := "scraml-tapir",
     version := "0.1",
     defaultTypes := scraml.DefaultTypes(
@@ -31,7 +32,6 @@ lazy val root = (project in file("."))
       )
     ),
     Compile / sourceGenerators += runScraml,
-    libraryDependencies += "com.chuusai" %% "shapeless" % "2.3.7",
     libraryDependencies ++= Seq(
       "eu.timepit" %% "refined",
       "eu.timepit" %% "refined-cats"
@@ -40,8 +40,8 @@ lazy val root = (project in file("."))
         "io.circe" %% "circe-core",
         "io.circe" %% "circe-generic",
         "io.circe" %% "circe-parser",
-        "io.circe" %% "circe-refined"
     ).map(_ % circeVersion),
+    libraryDependencies += "io.circe" %% "circe-refined" % "0.15.1",
     libraryDependencies ++= Seq(
       "com.softwaremill.sttp.tapir" %% "tapir-core",
       "com.softwaremill.sttp.tapir" %% "tapir-json-circe"

--- a/src/sbt-test/sbt-scraml/tapir/project/build.properties
+++ b/src/sbt-test/sbt-scraml/tapir/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.10.5
+sbt.version = 1.10.7

--- a/src/sbt-test/sbt-scraml/tapir/test
+++ b/src/sbt-test/sbt-scraml/tapir/test
@@ -1,3 +1,6 @@
 > compile
 # compile again, should not yield errors
 > compile
+> clean
+> ++3.3
+> compile

--- a/src/sbt-test/sbt-scraml/two-specifications/build.sbt
+++ b/src/sbt-test/sbt-scraml/two-specifications/build.sbt
@@ -1,6 +1,7 @@
 lazy val root = (project in file("."))
   .settings(
-    scalaVersion := "2.13.15",
+    scalaVersion := "2.13.16",
+    crossScalaVersions ++= Seq("3.3.4"),
     name := "scraml-two-specifications",
     version := "0.1",
     librarySupport := Set(

--- a/src/sbt-test/sbt-scraml/two-specifications/project/build.properties
+++ b/src/sbt-test/sbt-scraml/two-specifications/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.10.5
+sbt.version = 1.10.7

--- a/src/sbt-test/sbt-scraml/two-specifications/test
+++ b/src/sbt-test/sbt-scraml/two-specifications/test
@@ -4,3 +4,9 @@ $ exists target/scala-2.13/src_managed/main/scraml/inline/datatypes.scala
 $ exists target/scala-2.13/src_managed/main/scraml/inline/package.scala
 $ exists target/scala-2.13/src_managed/main/scraml/simple/datatypes.scala
 $ exists target/scala-2.13/src_managed/main/scraml/simple/package.scala
+> ++3.3
+> compile
+$ exists target/scala-2.13/src_managed/main/scraml/inline/datatypes.scala
+$ exists target/scala-2.13/src_managed/main/scraml/inline/package.scala
+$ exists target/scala-2.13/src_managed/main/scraml/simple/datatypes.scala
+$ exists target/scala-2.13/src_managed/main/scraml/simple/package.scala

--- a/src/test/scala/scraml/DefaultModelGenSpec.scala
+++ b/src/test/scala/scraml/DefaultModelGenSpec.scala
@@ -69,12 +69,20 @@ class DefaultModelGenSpec extends AnyFlatSpec with Matchers {
         )
 
         enumType.source.source.toString() should be("sealed trait SomeEnum")
-        enumType.source.companion.map(_.toString()) should be(Some(s"""object SomeEnum {
+        enumType.source.companion.map(_.syntax) should be(Some(s"""object SomeEnum {
              |  case object A extends SomeEnum
              |  case object B extends SomeEnum
-             |  case object ENUM extends SomeEnum
-             |  case object TYPE extends SomeEnum
+             |  case object enum extends SomeEnum
+             |  case object `type` extends SomeEnum
              |}""".stripMargin))
+        enumType.source.companion.map(_.printSyntaxFor(scala.meta.dialects.Scala3)) should be(
+          Some(s"""object SomeEnum {
+             |  case object A extends SomeEnum
+             |  case object B extends SomeEnum
+             |  case object `enum` extends SomeEnum
+             |  case object `type` extends SomeEnum
+             |}""".stripMargin)
+        )
 
         packageObject.source.source.toString should be("package object scraml")
 

--- a/src/test/scala/scraml/SphereJsonSupportSpec.scala
+++ b/src/test/scala/scraml/SphereJsonSupportSpec.scala
@@ -45,8 +45,8 @@ class SphereJsonSupportSpec extends AnyFlatSpec with Matchers {
         someEnum.source.companion.map(_.toString()) should be(Some(s"""object SomeEnum {
             |  case object A extends SomeEnum
             |  case object B extends SomeEnum
-            |  case object ENUM extends SomeEnum
-            |  case object TYPE extends SomeEnum
+            |  case object enum extends SomeEnum
+            |  case object `type` extends SomeEnum
             |  import io.sphere.json.ToJSON
             |  import io.sphere.json.FromJSON
             |  import io.sphere.json.JSONParseError
@@ -61,9 +61,9 @@ class SphereJsonSupportSpec extends AnyFlatSpec with Matchers {
             |    case "B" =>
             |      B.valid
             |    case "enum" =>
-            |      ENUM.valid
+            |      enum.valid
             |    case "type" =>
-            |      TYPE.valid
+            |      `type`.valid
             |    case other =>
             |      JSONParseError(s"not a instance of required enum: $$other").invalidNel
             |  }

--- a/src/test/scala/scraml/libs/CirceJsonSupportSpec.scala
+++ b/src/test/scala/scraml/libs/CirceJsonSupportSpec.scala
@@ -249,7 +249,9 @@ class CirceJsonSupportSpec extends AnyFlatSpec with Matchers with SourceCodeForm
           )
         )
 
-        someEnum.source.companion.map(_.printSyntaxFor(dialects.Scala3).stripTrailingSpaces) should be(
+        someEnum.source.companion.map(
+          _.printSyntaxFor(dialects.Scala3).stripTrailingSpaces
+        ) should be(
           Some(
             s"""object SomeEnum {
                |  case object A extends SomeEnum
@@ -494,7 +496,7 @@ class CirceJsonSupportSpec extends AnyFlatSpec with Matchers with SourceCodeForm
       librarySupport = Set(
         CirceJsonSupport(imports = Seq("io.circe.Decoder.decodeLocalDateTime"))
       ),
-      scalaVersion = None,
+      scalaVersion = None
     )
 
     val generated = ModelGenRunner.run(DefaultModelGen)(params).unsafeRunSync()

--- a/src/test/scala/scraml/libs/RefinedSupportSpec.scala
+++ b/src/test/scala/scraml/libs/RefinedSupportSpec.scala
@@ -75,22 +75,21 @@ class RefinedSupportSpec extends AnyWordSpec with Matchers with SourceCodeFormat
             |  import eu.timepit.refined.collection._
             |  import eu.timepit.refined.numeric._
             |  import eu.timepit.refined.string._
-            |  import shapeless.Witness
-            |  type IdType = Refined[String, And[MinSize[Witness.`1`.T], And[MaxSize[Witness.`10`.T], MatchesRegex[Witness.`"^[A-z0-9-.]+$"`.T]]]]
+            |  type IdType = Refined[String, And[MinSize[1], And[MaxSize[10], MatchesRegex["^[A-z0-9-.]+$"]]]]
             |  object IdType {
             |    import eu.timepit.refined.api._
-            |    type ResultType = Refined[String, And[MinSize[Witness.`1`.T], And[MaxSize[Witness.`10`.T], MatchesRegex[Witness.`"^[A-z0-9-.]+$"`.T]]]]
+            |    type ResultType = Refined[String, And[MinSize[1], And[MaxSize[10], MatchesRegex["^[A-z0-9-.]+$"]]]]
             |    private val rt = RefinedType.apply[ResultType]
             |    def apply(candidate: String): Either[IllegalArgumentException, ResultType] = from(candidate)
             |    def from(candidate: String): Either[IllegalArgumentException, ResultType] = rt.refine(candidate).left.map(msg => new IllegalArgumentException(msg))
             |    def unapply(candidate: String): Option[ResultType] = from(candidate).toOption
             |    def unsafeFrom(candidate: String): ResultType = rt.unsafeRefine(candidate)
             |  }
-            |  type OptionalCustomArrayTypePropItemPredicate = GreaterEqual[Witness.`0.0`.T]
-            |  type OptionalCustomArrayTypePropType = Option[Refined[Set[scala.math.BigDecimal], And[MinSize[Witness.`1`.T], And[MaxSize[Witness.`100`.T], Forall[OptionalCustomArrayTypePropItemPredicate]]]]]
+            |  type OptionalCustomArrayTypePropItemPredicate = GreaterEqual[0]
+            |  type OptionalCustomArrayTypePropType = Option[Refined[Set[scala.math.BigDecimal], And[MinSize[1], And[MaxSize[100], Forall[OptionalCustomArrayTypePropItemPredicate]]]]]
             |  object OptionalCustomArrayTypePropType {
             |    import eu.timepit.refined.api._
-            |    type ResultType = Refined[Set[scala.math.BigDecimal], And[MinSize[Witness.`1`.T], And[MaxSize[Witness.`100`.T], Forall[OptionalCustomArrayTypePropItemPredicate]]]]
+            |    type ResultType = Refined[Set[scala.math.BigDecimal], And[MinSize[1], And[MaxSize[100], Forall[OptionalCustomArrayTypePropItemPredicate]]]]
             |    private val rt = RefinedType.apply[ResultType]
             |    lazy val default: Option[ResultType] = None
             |    def apply(candidate: Set[scala.math.BigDecimal]): Either[IllegalArgumentException, Option[ResultType]] = from(Option(candidate))
@@ -104,10 +103,10 @@ class RefinedSupportSpec extends AnyWordSpec with Matchers with SourceCodeFormat
             |    def unapply(candidate: Option[Set[scala.math.BigDecimal]]): Option[ResultType] = from(candidate).fold(_ => None, a => a)
             |    def unsafeFrom(candidate: Option[Set[scala.math.BigDecimal]]): Option[ResultType] = candidate.map(rt.unsafeRefine)
             |  }
-            |  type BarType = Option[Refined[String, MatchesRegex[Witness.`"^[A-z]+$"`.T]]]
+            |  type BarType = Option[Refined[String, MatchesRegex["^[A-z]+$"]]]
             |  object BarType {
             |    import eu.timepit.refined.api._
-            |    type ResultType = Refined[String, MatchesRegex[Witness.`"^[A-z]+$"`.T]]
+            |    type ResultType = Refined[String, MatchesRegex["^[A-z]+$"]]
             |    private val rt = RefinedType.apply[ResultType]
             |    lazy val default: Option[ResultType] = unsafeFrom(None)
             |    def apply(candidate: String): Either[IllegalArgumentException, Option[ResultType]] = from(Option(candidate))
@@ -121,38 +120,38 @@ class RefinedSupportSpec extends AnyWordSpec with Matchers with SourceCodeFormat
             |    def unapply(candidate: Option[String]): Option[ResultType] = from(candidate).fold(_ => None, a => a)
             |    def unsafeFrom(candidate: Option[String]): Option[ResultType] = candidate.map(rt.unsafeRefine)
             |  }
-            |  type NumberPropType = Refined[Float, Interval.Closed[Witness.`0`.T, Witness.`99.99999`.T]]
+            |  type NumberPropType = Refined[Float, Interval.Closed[0, 99.99999d]]
             |  object NumberPropType {
             |    import eu.timepit.refined.api._
-            |    type ResultType = Refined[Float, Interval.Closed[Witness.`0`.T, Witness.`99.99999`.T]]
+            |    type ResultType = Refined[Float, Interval.Closed[0, 99.99999d]]
             |    private val rt = RefinedType.apply[ResultType]
             |    def apply(candidate: Float): Either[IllegalArgumentException, ResultType] = from(candidate)
             |    def from(candidate: Float): Either[IllegalArgumentException, ResultType] = rt.refine(candidate).left.map(msg => new IllegalArgumentException(msg))
             |    def unapply(candidate: Float): Option[ResultType] = from(candidate).toOption
             |    def unsafeFrom(candidate: Float): ResultType = rt.unsafeRefine(candidate)
             |  }
-            |  type CustomNumberPropType = Refined[scala.math.BigDecimal, LessEqual[Witness.`99.99999`.T]]
+            |  type CustomNumberPropType = Refined[scala.math.BigDecimal, LessEqual[99.99999d]]
             |  object CustomNumberPropType {
             |    import eu.timepit.refined.api._
-            |    type ResultType = Refined[scala.math.BigDecimal, LessEqual[Witness.`99.99999`.T]]
+            |    type ResultType = Refined[scala.math.BigDecimal, LessEqual[99.99999d]]
             |    private val rt = RefinedType.apply[ResultType]
             |    def apply(candidate: scala.math.BigDecimal): Either[IllegalArgumentException, ResultType] = from(candidate)
             |    def from(candidate: scala.math.BigDecimal): Either[IllegalArgumentException, ResultType] = rt.refine(candidate).left.map(msg => new IllegalArgumentException(msg))
             |    def unapply(candidate: scala.math.BigDecimal): Option[ResultType] = from(candidate).toOption
             |    def unsafeFrom(candidate: scala.math.BigDecimal): ResultType = rt.unsafeRefine(candidate)
             |  }
-            |  type CustomArrayTypePropItemPredicate = Interval.Closed[Witness.`1.23`.T, Witness.`4.56`.T]
-            |  type CustomArrayTypePropType = Refined[Vector[scala.math.BigDecimal], And[MaxSize[Witness.`100`.T], Forall[CustomArrayTypePropItemPredicate]]]
+            |  type CustomArrayTypePropItemPredicate = Interval.Closed[1.23d, 4.56d]
+            |  type CustomArrayTypePropType = Refined[Vector[scala.math.BigDecimal], And[MaxSize[100], Forall[CustomArrayTypePropItemPredicate]]]
             |  object CustomArrayTypePropType {
             |    import eu.timepit.refined.api._
-            |    type ResultType = Refined[Vector[scala.math.BigDecimal], And[MaxSize[Witness.`100`.T], Forall[CustomArrayTypePropItemPredicate]]]
+            |    type ResultType = Refined[Vector[scala.math.BigDecimal], And[MaxSize[100], Forall[CustomArrayTypePropItemPredicate]]]
             |    private val rt = RefinedType.apply[ResultType]
             |    def apply(candidate: Vector[scala.math.BigDecimal]): Either[IllegalArgumentException, ResultType] = from(candidate)
             |    def from(candidate: Vector[scala.math.BigDecimal]): Either[IllegalArgumentException, ResultType] = rt.refine(candidate).left.map(msg => new IllegalArgumentException(msg))
             |    def unapply(candidate: Vector[scala.math.BigDecimal]): Option[ResultType] = from(candidate).toOption
             |    def unsafeFrom(candidate: Vector[scala.math.BigDecimal]): ResultType = rt.unsafeRefine(candidate)
             |  }
-            |  type OptionalStringArrayItemPredicate = And[MinSize[Witness.`2`.T], And[MaxSize[Witness.`42`.T], MatchesRegex[Witness.`"^[A-z0-9]+$"`.T]]]
+            |  type OptionalStringArrayItemPredicate = And[MinSize[2], And[MaxSize[42], MatchesRegex["^[A-z0-9]+$"]]]
             |  type OptionalStringArrayType = Option[Refined[scala.collection.immutable.List[String], Forall[OptionalStringArrayItemPredicate]]]
             |  object OptionalStringArrayType {
             |    import eu.timepit.refined.api._
@@ -243,10 +242,9 @@ class RefinedSupportSpec extends AnyWordSpec with Matchers with SourceCodeFormat
             |  import eu.timepit.refined.collection._
             |  import eu.timepit.refined.numeric._
             |  import eu.timepit.refined.string._
-            |  import shapeless.Witness
-            |  type IdType = Refined[String, And[MinSize[Witness.`1`.T], And[MaxSize[Witness.`10`.T], MatchesRegex[Witness.`"^[A-z0-9-.]+$"`.T]]]]
-            |  type OptionalCustomArrayTypePropItemPredicate = GreaterEqual[Witness.`0.0`.T]
-            |  type OptionalCustomArrayTypePropType = Option[Refined[Set[scala.math.BigDecimal], And[MinSize[Witness.`1`.T], And[MaxSize[Witness.`100`.T], Forall[OptionalCustomArrayTypePropItemPredicate]]]]]
+            |  type IdType = Refined[String, And[MinSize[1], And[MaxSize[10], MatchesRegex["^[A-z0-9-.]+$"]]]]
+            |  type OptionalCustomArrayTypePropItemPredicate = GreaterEqual[0]
+            |  type OptionalCustomArrayTypePropType = Option[Refined[Set[scala.math.BigDecimal], And[MinSize[1], And[MaxSize[100], Forall[OptionalCustomArrayTypePropItemPredicate]]]]]
             |}""".stripMargin.stripTrailingSpaces
         )
       )
@@ -318,22 +316,21 @@ class RefinedSupportSpec extends AnyWordSpec with Matchers with SourceCodeFormat
             |  import eu.timepit.refined.collection._
             |  import eu.timepit.refined.numeric._
             |  import eu.timepit.refined.string._
-            |  import shapeless.Witness
-            |  type IdType = Refined[String, And[MinSize[Witness.`1`.T], And[MaxSize[Witness.`10`.T], MatchesRegex[Witness.`"^[A-z0-9-.]+$"`.T]]]]
+            |  type IdType = Refined[String, And[MinSize[1], And[MaxSize[10], MatchesRegex["^[A-z0-9-.]+$"]]]]
             |  object IdType {
             |    import eu.timepit.refined.api._
-            |    type ResultType = Refined[String, And[MinSize[Witness.`1`.T], And[MaxSize[Witness.`10`.T], MatchesRegex[Witness.`"^[A-z0-9-.]+$"`.T]]]]
+            |    type ResultType = Refined[String, And[MinSize[1], And[MaxSize[10], MatchesRegex["^[A-z0-9-.]+$"]]]]
             |    private val rt = RefinedType.apply[ResultType]
             |    def apply(candidate: String): Either[IllegalArgumentException, ResultType] = from(candidate)
             |    def from(candidate: String): Either[IllegalArgumentException, ResultType] = rt.refine(candidate).left.map(msg => new IllegalArgumentException(msg))
             |    def unapply(candidate: String): Option[ResultType] = from(candidate).toOption
             |    def unsafeFrom(candidate: String): ResultType = rt.unsafeRefine(candidate)
             |  }
-            |  type OptionalCustomArrayTypePropItemPredicate = GreaterEqual[Witness.`0.0`.T]
-            |  type OptionalCustomArrayTypePropType = Option[Refined[Set[scala.math.BigDecimal], And[MinSize[Witness.`1`.T], And[MaxSize[Witness.`100`.T], Forall[OptionalCustomArrayTypePropItemPredicate]]]]]
+            |  type OptionalCustomArrayTypePropItemPredicate = GreaterEqual[0]
+            |  type OptionalCustomArrayTypePropType = Option[Refined[Set[scala.math.BigDecimal], And[MinSize[1], And[MaxSize[100], Forall[OptionalCustomArrayTypePropItemPredicate]]]]]
             |  object OptionalCustomArrayTypePropType {
             |    import eu.timepit.refined.api._
-            |    type ResultType = Refined[Set[scala.math.BigDecimal], And[MinSize[Witness.`1`.T], And[MaxSize[Witness.`100`.T], Forall[OptionalCustomArrayTypePropItemPredicate]]]]
+            |    type ResultType = Refined[Set[scala.math.BigDecimal], And[MinSize[1], And[MaxSize[100], Forall[OptionalCustomArrayTypePropItemPredicate]]]]
             |    private val rt = RefinedType.apply[ResultType]
             |    lazy val default: Option[ResultType] = None
             |    def apply(candidate: Set[scala.math.BigDecimal]): Either[IllegalArgumentException, Option[ResultType]] = from(Option(candidate))
@@ -347,10 +344,10 @@ class RefinedSupportSpec extends AnyWordSpec with Matchers with SourceCodeFormat
             |    def unapply(candidate: Option[Set[scala.math.BigDecimal]]): Option[ResultType] = from(candidate).fold(_ => None, a => a)
             |    def unsafeFrom(candidate: Option[Set[scala.math.BigDecimal]]): Option[ResultType] = candidate.map(rt.unsafeRefine)
             |  }
-            |  type BarType = Option[Refined[String, MatchesRegex[Witness.`"^[A-z]+$"`.T]]]
+            |  type BarType = Option[Refined[String, MatchesRegex["^[A-z]+$"]]]
             |  object BarType {
             |    import eu.timepit.refined.api._
-            |    type ResultType = Refined[String, MatchesRegex[Witness.`"^[A-z]+$"`.T]]
+            |    type ResultType = Refined[String, MatchesRegex["^[A-z]+$"]]
             |    private val rt = RefinedType.apply[ResultType]
             |    lazy val default: Option[ResultType] = unsafeFrom(None)
             |    def apply(candidate: String): Either[IllegalArgumentException, Option[ResultType]] = from(Option(candidate))
@@ -364,38 +361,38 @@ class RefinedSupportSpec extends AnyWordSpec with Matchers with SourceCodeFormat
             |    def unapply(candidate: Option[String]): Option[ResultType] = from(candidate).fold(_ => None, a => a)
             |    def unsafeFrom(candidate: Option[String]): Option[ResultType] = candidate.map(rt.unsafeRefine)
             |  }
-            |  type NumberPropType = Refined[Float, Interval.Closed[Witness.`0`.T, Witness.`99.99999`.T]]
+            |  type NumberPropType = Refined[Float, Interval.Closed[0, 99.99999d]]
             |  object NumberPropType {
             |    import eu.timepit.refined.api._
-            |    type ResultType = Refined[Float, Interval.Closed[Witness.`0`.T, Witness.`99.99999`.T]]
+            |    type ResultType = Refined[Float, Interval.Closed[0, 99.99999d]]
             |    private val rt = RefinedType.apply[ResultType]
             |    def apply(candidate: Float): Either[IllegalArgumentException, ResultType] = from(candidate)
             |    def from(candidate: Float): Either[IllegalArgumentException, ResultType] = rt.refine(candidate).left.map(msg => new IllegalArgumentException(msg))
             |    def unapply(candidate: Float): Option[ResultType] = from(candidate).toOption
             |    def unsafeFrom(candidate: Float): ResultType = rt.unsafeRefine(candidate)
             |  }
-            |  type CustomNumberPropType = Refined[scala.math.BigDecimal, LessEqual[Witness.`99.99999`.T]]
+            |  type CustomNumberPropType = Refined[scala.math.BigDecimal, LessEqual[99.99999d]]
             |  object CustomNumberPropType {
             |    import eu.timepit.refined.api._
-            |    type ResultType = Refined[scala.math.BigDecimal, LessEqual[Witness.`99.99999`.T]]
+            |    type ResultType = Refined[scala.math.BigDecimal, LessEqual[99.99999d]]
             |    private val rt = RefinedType.apply[ResultType]
             |    def apply(candidate: scala.math.BigDecimal): Either[IllegalArgumentException, ResultType] = from(candidate)
             |    def from(candidate: scala.math.BigDecimal): Either[IllegalArgumentException, ResultType] = rt.refine(candidate).left.map(msg => new IllegalArgumentException(msg))
             |    def unapply(candidate: scala.math.BigDecimal): Option[ResultType] = from(candidate).toOption
             |    def unsafeFrom(candidate: scala.math.BigDecimal): ResultType = rt.unsafeRefine(candidate)
             |  }
-            |  type CustomArrayTypePropItemPredicate = Interval.Closed[Witness.`1.23`.T, Witness.`4.56`.T]
-            |  type CustomArrayTypePropType = Refined[Vector[scala.math.BigDecimal], And[MaxSize[Witness.`100`.T], Forall[CustomArrayTypePropItemPredicate]]]
+            |  type CustomArrayTypePropItemPredicate = Interval.Closed[1.23d, 4.56d]
+            |  type CustomArrayTypePropType = Refined[Vector[scala.math.BigDecimal], And[MaxSize[100], Forall[CustomArrayTypePropItemPredicate]]]
             |  object CustomArrayTypePropType {
             |    import eu.timepit.refined.api._
-            |    type ResultType = Refined[Vector[scala.math.BigDecimal], And[MaxSize[Witness.`100`.T], Forall[CustomArrayTypePropItemPredicate]]]
+            |    type ResultType = Refined[Vector[scala.math.BigDecimal], And[MaxSize[100], Forall[CustomArrayTypePropItemPredicate]]]
             |    private val rt = RefinedType.apply[ResultType]
             |    def apply(candidate: Vector[scala.math.BigDecimal]): Either[IllegalArgumentException, ResultType] = from(candidate)
             |    def from(candidate: Vector[scala.math.BigDecimal]): Either[IllegalArgumentException, ResultType] = rt.refine(candidate).left.map(msg => new IllegalArgumentException(msg))
             |    def unapply(candidate: Vector[scala.math.BigDecimal]): Option[ResultType] = from(candidate).toOption
             |    def unsafeFrom(candidate: Vector[scala.math.BigDecimal]): ResultType = rt.unsafeRefine(candidate)
             |  }
-            |  type OptionalStringArrayItemPredicate = And[MinSize[Witness.`2`.T], And[MaxSize[Witness.`42`.T], MatchesRegex[Witness.`"^[A-z0-9]+$"`.T]]]
+            |  type OptionalStringArrayItemPredicate = And[MinSize[2], And[MaxSize[42], MatchesRegex["^[A-z0-9]+$"]]]
             |  type OptionalStringArrayType = Option[Refined[scala.collection.immutable.List[String], Forall[OptionalStringArrayItemPredicate]]]
             |  object OptionalStringArrayType {
             |    import eu.timepit.refined.api._
@@ -554,22 +551,21 @@ class RefinedSupportSpec extends AnyWordSpec with Matchers with SourceCodeFormat
             |  import eu.timepit.refined.collection._
             |  import eu.timepit.refined.numeric._
             |  import eu.timepit.refined.string._
-            |  import shapeless.Witness
-            |  type IdType = Refined[String, And[MinSize[Witness.`1`.T], And[MaxSize[Witness.`10`.T], MatchesRegex[Witness.`"^[A-z0-9-.]+$"`.T]]]]
+            |  type IdType = Refined[String, And[MinSize[1], And[MaxSize[10], MatchesRegex["^[A-z0-9-.]+$"]]]]
             |  object IdType {
             |    import eu.timepit.refined.api._
-            |    type ResultType = Refined[String, And[MinSize[Witness.`1`.T], And[MaxSize[Witness.`10`.T], MatchesRegex[Witness.`"^[A-z0-9-.]+$"`.T]]]]
+            |    type ResultType = Refined[String, And[MinSize[1], And[MaxSize[10], MatchesRegex["^[A-z0-9-.]+$"]]]]
             |    private val rt = RefinedType.apply[ResultType]
             |    def apply(candidate: String): Either[IllegalArgumentException, ResultType] = from(candidate)
             |    def from(candidate: String): Either[IllegalArgumentException, ResultType] = rt.refine(candidate).left.map(msg => new IllegalArgumentException(msg))
             |    def unapply(candidate: String): Option[ResultType] = from(candidate).toOption
             |    def unsafeFrom(candidate: String): ResultType = rt.unsafeRefine(candidate)
             |  }
-            |  type OptionalCustomArrayTypePropItemPredicate = GreaterEqual[Witness.`0.0`.T]
-            |  type OptionalCustomArrayTypePropType = Option[Refined[Set[scala.math.BigDecimal], And[MinSize[Witness.`1`.T], And[MaxSize[Witness.`100`.T], Forall[OptionalCustomArrayTypePropItemPredicate]]]]]
+            |  type OptionalCustomArrayTypePropItemPredicate = GreaterEqual[0]
+            |  type OptionalCustomArrayTypePropType = Option[Refined[Set[scala.math.BigDecimal], And[MinSize[1], And[MaxSize[100], Forall[OptionalCustomArrayTypePropItemPredicate]]]]]
             |  object OptionalCustomArrayTypePropType {
             |    import eu.timepit.refined.api._
-            |    type ResultType = Refined[Set[scala.math.BigDecimal], And[MinSize[Witness.`1`.T], And[MaxSize[Witness.`100`.T], Forall[OptionalCustomArrayTypePropItemPredicate]]]]
+            |    type ResultType = Refined[Set[scala.math.BigDecimal], And[MinSize[1], And[MaxSize[100], Forall[OptionalCustomArrayTypePropItemPredicate]]]]
             |    private val rt = RefinedType.apply[ResultType]
             |    lazy val default: Option[ResultType] = None
             |    def apply(candidate: Set[scala.math.BigDecimal]): Either[IllegalArgumentException, Option[ResultType]] = from(Option(candidate))
@@ -583,10 +579,10 @@ class RefinedSupportSpec extends AnyWordSpec with Matchers with SourceCodeFormat
             |    def unapply(candidate: Option[Set[scala.math.BigDecimal]]): Option[ResultType] = from(candidate).fold(_ => None, a => a)
             |    def unsafeFrom(candidate: Option[Set[scala.math.BigDecimal]]): Option[ResultType] = candidate.map(rt.unsafeRefine)
             |  }
-            |  type BarType = Option[Refined[String, MatchesRegex[Witness.`"^[A-z]+$"`.T]]]
+            |  type BarType = Option[Refined[String, MatchesRegex["^[A-z]+$"]]]
             |  object BarType {
             |    import eu.timepit.refined.api._
-            |    type ResultType = Refined[String, MatchesRegex[Witness.`"^[A-z]+$"`.T]]
+            |    type ResultType = Refined[String, MatchesRegex["^[A-z]+$"]]
             |    private val rt = RefinedType.apply[ResultType]
             |    lazy val default: Option[ResultType] = unsafeFrom(None)
             |    def apply(candidate: String): Either[IllegalArgumentException, Option[ResultType]] = from(Option(candidate))
@@ -600,38 +596,38 @@ class RefinedSupportSpec extends AnyWordSpec with Matchers with SourceCodeFormat
             |    def unapply(candidate: Option[String]): Option[ResultType] = from(candidate).fold(_ => None, a => a)
             |    def unsafeFrom(candidate: Option[String]): Option[ResultType] = candidate.map(rt.unsafeRefine)
             |  }
-            |  type NumberPropType = Refined[Float, Interval.Closed[Witness.`0`.T, Witness.`99.99999`.T]]
+            |  type NumberPropType = Refined[Float, Interval.Closed[0, 99.99999d]]
             |  object NumberPropType {
             |    import eu.timepit.refined.api._
-            |    type ResultType = Refined[Float, Interval.Closed[Witness.`0`.T, Witness.`99.99999`.T]]
+            |    type ResultType = Refined[Float, Interval.Closed[0, 99.99999d]]
             |    private val rt = RefinedType.apply[ResultType]
             |    def apply(candidate: Float): Either[IllegalArgumentException, ResultType] = from(candidate)
             |    def from(candidate: Float): Either[IllegalArgumentException, ResultType] = rt.refine(candidate).left.map(msg => new IllegalArgumentException(msg))
             |    def unapply(candidate: Float): Option[ResultType] = from(candidate).toOption
             |    def unsafeFrom(candidate: Float): ResultType = rt.unsafeRefine(candidate)
             |  }
-            |  type CustomNumberPropType = Refined[scala.math.BigDecimal, LessEqual[Witness.`99.99999`.T]]
+            |  type CustomNumberPropType = Refined[scala.math.BigDecimal, LessEqual[99.99999d]]
             |  object CustomNumberPropType {
             |    import eu.timepit.refined.api._
-            |    type ResultType = Refined[scala.math.BigDecimal, LessEqual[Witness.`99.99999`.T]]
+            |    type ResultType = Refined[scala.math.BigDecimal, LessEqual[99.99999d]]
             |    private val rt = RefinedType.apply[ResultType]
             |    def apply(candidate: scala.math.BigDecimal): Either[IllegalArgumentException, ResultType] = from(candidate)
             |    def from(candidate: scala.math.BigDecimal): Either[IllegalArgumentException, ResultType] = rt.refine(candidate).left.map(msg => new IllegalArgumentException(msg))
             |    def unapply(candidate: scala.math.BigDecimal): Option[ResultType] = from(candidate).toOption
             |    def unsafeFrom(candidate: scala.math.BigDecimal): ResultType = rt.unsafeRefine(candidate)
             |  }
-            |  type CustomArrayTypePropItemPredicate = Interval.Closed[Witness.`1.23`.T, Witness.`4.56`.T]
-            |  type CustomArrayTypePropType = Refined[Vector[scala.math.BigDecimal], And[MaxSize[Witness.`100`.T], Forall[CustomArrayTypePropItemPredicate]]]
+            |  type CustomArrayTypePropItemPredicate = Interval.Closed[1.23d, 4.56d]
+            |  type CustomArrayTypePropType = Refined[Vector[scala.math.BigDecimal], And[MaxSize[100], Forall[CustomArrayTypePropItemPredicate]]]
             |  object CustomArrayTypePropType {
             |    import eu.timepit.refined.api._
-            |    type ResultType = Refined[Vector[scala.math.BigDecimal], And[MaxSize[Witness.`100`.T], Forall[CustomArrayTypePropItemPredicate]]]
+            |    type ResultType = Refined[Vector[scala.math.BigDecimal], And[MaxSize[100], Forall[CustomArrayTypePropItemPredicate]]]
             |    private val rt = RefinedType.apply[ResultType]
             |    def apply(candidate: Vector[scala.math.BigDecimal]): Either[IllegalArgumentException, ResultType] = from(candidate)
             |    def from(candidate: Vector[scala.math.BigDecimal]): Either[IllegalArgumentException, ResultType] = rt.refine(candidate).left.map(msg => new IllegalArgumentException(msg))
             |    def unapply(candidate: Vector[scala.math.BigDecimal]): Option[ResultType] = from(candidate).toOption
             |    def unsafeFrom(candidate: Vector[scala.math.BigDecimal]): ResultType = rt.unsafeRefine(candidate)
             |  }
-            |  type OptionalStringArrayItemPredicate = And[MinSize[Witness.`2`.T], And[MaxSize[Witness.`42`.T], MatchesRegex[Witness.`"^[A-z0-9]+$"`.T]]]
+            |  type OptionalStringArrayItemPredicate = And[MinSize[2], And[MaxSize[42], MatchesRegex["^[A-z0-9]+$"]]]
             |  type OptionalStringArrayType = Option[Refined[scala.collection.immutable.List[String], Forall[OptionalStringArrayItemPredicate]]]
             |  object OptionalStringArrayType {
             |    import eu.timepit.refined.api._
@@ -733,11 +729,10 @@ class RefinedSupportSpec extends AnyWordSpec with Matchers with SourceCodeFormat
             |  import eu.timepit.refined.collection._
             |  import eu.timepit.refined.numeric._
             |  import eu.timepit.refined.string._
-            |  import shapeless.Witness
-            |  type IdType = Refined[String, MatchesRegex[Witness.`"^[A-z]+$"`.T]]
+            |  type IdType = Refined[String, MatchesRegex["^[A-z]+$"]]
             |  object IdType {
             |    import eu.timepit.refined.api._
-            |    type ResultType = Refined[String, MatchesRegex[Witness.`"^[A-z]+$"`.T]]
+            |    type ResultType = Refined[String, MatchesRegex["^[A-z]+$"]]
             |    private val rt = RefinedType.apply[ResultType]
             |    def apply(candidate: String): Either[IllegalArgumentException, ResultType] = from(candidate)
             |    def from(candidate: String): Either[IllegalArgumentException, ResultType] = rt.refine(candidate).left.map(msg => new IllegalArgumentException(msg))
@@ -812,8 +807,7 @@ class RefinedSupportSpec extends AnyWordSpec with Matchers with SourceCodeFormat
             |  import eu.timepit.refined.collection._
             |  import eu.timepit.refined.numeric._
             |  import eu.timepit.refined.string._
-            |  import shapeless.Witness
-            |  type IdType = Option[Refined[String, And[MaxSize[Witness.`128`.T], MatchesRegex[Witness.`"^[A-z0-9]+$"`.T]]]]
+            |  type IdType = Option[Refined[String, And[MaxSize[128], MatchesRegex["^[A-z0-9]+$"]]]]
             |}""".stripMargin.stripTrailingSpaces
         )
       )
@@ -844,11 +838,10 @@ class RefinedSupportSpec extends AnyWordSpec with Matchers with SourceCodeFormat
             |  import eu.timepit.refined.collection._
             |  import eu.timepit.refined.numeric._
             |  import eu.timepit.refined.string._
-            |  import shapeless.Witness
-            |  type IdType = Refined[String, And[MaxSize[Witness.`128`.T], MatchesRegex[Witness.`"^[A-z0-9]+$"`.T]]]
+            |  type IdType = Refined[String, And[MaxSize[128], MatchesRegex["^[A-z0-9]+$"]]]
             |  object IdType {
             |    import eu.timepit.refined.api._
-            |    type ResultType = Refined[String, And[MaxSize[Witness.`128`.T], MatchesRegex[Witness.`"^[A-z0-9]+$"`.T]]]
+            |    type ResultType = Refined[String, And[MaxSize[128], MatchesRegex["^[A-z0-9]+$"]]]
             |    private val rt = RefinedType.apply[ResultType]
             |    def apply(candidate: String): Either[IllegalArgumentException, ResultType] = from(candidate)
             |    def from(candidate: String): Either[IllegalArgumentException, ResultType] = rt.refine(candidate).left.map(msg => new IllegalArgumentException(msg))
@@ -939,42 +932,41 @@ class RefinedSupportSpec extends AnyWordSpec with Matchers with SourceCodeFormat
             |  import eu.timepit.refined.collection._
             |  import eu.timepit.refined.numeric._
             |  import eu.timepit.refined.string._
-            |  import shapeless.Witness
-            |  type IdType = Refined[String, And[MinSize[Witness.`8`.T], And[MaxSize[Witness.`64`.T], MatchesRegex[Witness.`"^[A-z0-9-]*$"`.T]]]]
+            |  type IdType = Refined[String, And[MinSize[8], And[MaxSize[64], MatchesRegex["^[A-z0-9-]*$"]]]]
             |  object IdType {
             |    import eu.timepit.refined.api._
-            |    type ResultType = Refined[String, And[MinSize[Witness.`8`.T], And[MaxSize[Witness.`64`.T], MatchesRegex[Witness.`"^[A-z0-9-]*$"`.T]]]]
+            |    type ResultType = Refined[String, And[MinSize[8], And[MaxSize[64], MatchesRegex["^[A-z0-9-]*$"]]]]
             |    private val rt = RefinedType.apply[ResultType]
             |    def apply(candidate: String): Either[IllegalArgumentException, ResultType] = from(candidate)
             |    def from(candidate: String): Either[IllegalArgumentException, ResultType] = rt.refine(candidate).left.map(msg => new IllegalArgumentException(msg))
             |    def unapply(candidate: String): Option[ResultType] = from(candidate).toOption
             |    def unsafeFrom(candidate: String): ResultType = rt.unsafeRefine(candidate)
             |  }
-            |  type CountType = Refined[Int, GreaterEqual[Witness.`0`.T]]
+            |  type CountType = Refined[Int, GreaterEqual[0]]
             |  object CountType {
             |    import eu.timepit.refined.api._
-            |    type ResultType = Refined[Int, GreaterEqual[Witness.`0`.T]]
+            |    type ResultType = Refined[Int, GreaterEqual[0]]
             |    private val rt = RefinedType.apply[ResultType]
             |    def apply(candidate: Int): Either[IllegalArgumentException, ResultType] = from(candidate)
             |    def from(candidate: Int): Either[IllegalArgumentException, ResultType] = rt.refine(candidate).left.map(msg => new IllegalArgumentException(msg))
             |    def unapply(candidate: Int): Option[ResultType] = from(candidate).toOption
             |    def unsafeFrom(candidate: Int): ResultType = rt.unsafeRefine(candidate)
             |  }
-            |  type AtMost100Type = Refined[Float, LessEqual[Witness.`100.0`.T]]
+            |  type AtMost100Type = Refined[Float, LessEqual[100]]
             |  object AtMost100Type {
             |    import eu.timepit.refined.api._
-            |    type ResultType = Refined[Float, LessEqual[Witness.`100.0`.T]]
+            |    type ResultType = Refined[Float, LessEqual[100]]
             |    private val rt = RefinedType.apply[ResultType]
             |    def apply(candidate: Float): Either[IllegalArgumentException, ResultType] = from(candidate)
             |    def from(candidate: Float): Either[IllegalArgumentException, ResultType] = rt.refine(candidate).left.map(msg => new IllegalArgumentException(msg))
             |    def unapply(candidate: Float): Option[ResultType] = from(candidate).toOption
             |    def unsafeFrom(candidate: Float): ResultType = rt.unsafeRefine(candidate)
             |  }
-            |  type StringArrayItemPredicate = And[MinSize[Witness.`2`.T], And[MaxSize[Witness.`99`.T], MatchesRegex[Witness.`"^[A-z0-9]+$"`.T]]]
-            |  type StringArrayType = Refined[scala.collection.immutable.List[String], And[MinSize[Witness.`1`.T], And[MaxSize[Witness.`5`.T], Forall[StringArrayItemPredicate]]]]
+            |  type StringArrayItemPredicate = And[MinSize[2], And[MaxSize[99], MatchesRegex["^[A-z0-9]+$"]]]
+            |  type StringArrayType = Refined[scala.collection.immutable.List[String], And[MinSize[1], And[MaxSize[5], Forall[StringArrayItemPredicate]]]]
             |  object StringArrayType {
             |    import eu.timepit.refined.api._
-            |    type ResultType = Refined[scala.collection.immutable.List[String], And[MinSize[Witness.`1`.T], And[MaxSize[Witness.`5`.T], Forall[StringArrayItemPredicate]]]]
+            |    type ResultType = Refined[scala.collection.immutable.List[String], And[MinSize[1], And[MaxSize[5], Forall[StringArrayItemPredicate]]]]
             |    private val rt = RefinedType.apply[ResultType]
             |    def apply(candidate: scala.collection.immutable.List[String]): Either[IllegalArgumentException, ResultType] = from(candidate)
             |    def from(candidate: scala.collection.immutable.List[String]): Either[IllegalArgumentException, ResultType] = rt.refine(candidate).left.map(msg => new IllegalArgumentException(msg))
@@ -1074,42 +1066,41 @@ class RefinedSupportSpec extends AnyWordSpec with Matchers with SourceCodeFormat
             |  import eu.timepit.refined.collection._
             |  import eu.timepit.refined.numeric._
             |  import eu.timepit.refined.string._
-            |  import shapeless.Witness
-            |  type IdType = Refined[String, And[MinSize[Witness.`8`.T], And[MaxSize[Witness.`64`.T], MatchesRegex[Witness.`"^[A-z0-9-]*$"`.T]]]]
+            |  type IdType = Refined[String, And[MinSize[8], And[MaxSize[64], MatchesRegex["^[A-z0-9-]*$"]]]]
             |  object IdType {
             |    import eu.timepit.refined.api._
-            |    type ResultType = Refined[String, And[MinSize[Witness.`8`.T], And[MaxSize[Witness.`64`.T], MatchesRegex[Witness.`"^[A-z0-9-]*$"`.T]]]]
+            |    type ResultType = Refined[String, And[MinSize[8], And[MaxSize[64], MatchesRegex["^[A-z0-9-]*$"]]]]
             |    private val rt = RefinedType.apply[ResultType]
             |    def apply(candidate: String): Either[IllegalArgumentException, ResultType] = from(candidate)
             |    def from(candidate: String): Either[IllegalArgumentException, ResultType] = rt.refine(candidate).left.map(msg => new IllegalArgumentException(msg))
             |    def unapply(candidate: String): Option[ResultType] = from(candidate).toOption
             |    def unsafeFrom(candidate: String): ResultType = rt.unsafeRefine(candidate)
             |  }
-            |  type CountType = Refined[Int, GreaterEqual[Witness.`0`.T]]
+            |  type CountType = Refined[Int, GreaterEqual[0]]
             |  object CountType {
             |    import eu.timepit.refined.api._
-            |    type ResultType = Refined[Int, GreaterEqual[Witness.`0`.T]]
+            |    type ResultType = Refined[Int, GreaterEqual[0]]
             |    private val rt = RefinedType.apply[ResultType]
             |    def apply(candidate: Int): Either[IllegalArgumentException, ResultType] = from(candidate)
             |    def from(candidate: Int): Either[IllegalArgumentException, ResultType] = rt.refine(candidate).left.map(msg => new IllegalArgumentException(msg))
             |    def unapply(candidate: Int): Option[ResultType] = from(candidate).toOption
             |    def unsafeFrom(candidate: Int): ResultType = rt.unsafeRefine(candidate)
             |  }
-            |  type AtMost100Type = Refined[Float, LessEqual[Witness.`100.0`.T]]
+            |  type AtMost100Type = Refined[Float, LessEqual[100]]
             |  object AtMost100Type {
             |    import eu.timepit.refined.api._
-            |    type ResultType = Refined[Float, LessEqual[Witness.`100.0`.T]]
+            |    type ResultType = Refined[Float, LessEqual[100]]
             |    private val rt = RefinedType.apply[ResultType]
             |    def apply(candidate: Float): Either[IllegalArgumentException, ResultType] = from(candidate)
             |    def from(candidate: Float): Either[IllegalArgumentException, ResultType] = rt.refine(candidate).left.map(msg => new IllegalArgumentException(msg))
             |    def unapply(candidate: Float): Option[ResultType] = from(candidate).toOption
             |    def unsafeFrom(candidate: Float): ResultType = rt.unsafeRefine(candidate)
             |  }
-            |  type StringArrayItemPredicate = And[MinSize[Witness.`2`.T], And[MaxSize[Witness.`99`.T], MatchesRegex[Witness.`"^[A-z0-9]+$"`.T]]]
-            |  type StringArrayType = Refined[scala.collection.immutable.List[String], And[MinSize[Witness.`1`.T], And[MaxSize[Witness.`5`.T], Forall[StringArrayItemPredicate]]]]
+            |  type StringArrayItemPredicate = And[MinSize[2], And[MaxSize[99], MatchesRegex["^[A-z0-9]+$"]]]
+            |  type StringArrayType = Refined[scala.collection.immutable.List[String], And[MinSize[1], And[MaxSize[5], Forall[StringArrayItemPredicate]]]]
             |  object StringArrayType {
             |    import eu.timepit.refined.api._
-            |    type ResultType = Refined[scala.collection.immutable.List[String], And[MinSize[Witness.`1`.T], And[MaxSize[Witness.`5`.T], Forall[StringArrayItemPredicate]]]]
+            |    type ResultType = Refined[scala.collection.immutable.List[String], And[MinSize[1], And[MaxSize[5], Forall[StringArrayItemPredicate]]]]
             |    private val rt = RefinedType.apply[ResultType]
             |    def apply(candidate: scala.collection.immutable.List[String]): Either[IllegalArgumentException, ResultType] = from(candidate)
             |    def from(candidate: scala.collection.immutable.List[String]): Either[IllegalArgumentException, ResultType] = rt.refine(candidate).left.map(msg => new IllegalArgumentException(msg))
@@ -1202,11 +1193,10 @@ class RefinedSupportSpec extends AnyWordSpec with Matchers with SourceCodeFormat
             |  import eu.timepit.refined.collection._
             |  import eu.timepit.refined.numeric._
             |  import eu.timepit.refined.string._
-            |  import shapeless.Witness
-            |  type MessageType = Refined[String, And[MinSize[Witness.`4`.T], And[MaxSize[Witness.`64`.T], MatchesRegex[Witness.`"^[A-z0-9 ]*$"`.T]]]]
+            |  type MessageType = Refined[String, And[MinSize[4], And[MaxSize[64], MatchesRegex["^[A-z0-9 ]*$"]]]]
             |  object MessageType {
             |    import eu.timepit.refined.api._
-            |    type ResultType = Refined[String, And[MinSize[Witness.`4`.T], And[MaxSize[Witness.`64`.T], MatchesRegex[Witness.`"^[A-z0-9 ]*$"`.T]]]]
+            |    type ResultType = Refined[String, And[MinSize[4], And[MaxSize[64], MatchesRegex["^[A-z0-9 ]*$"]]]]
             |    private val rt = RefinedType.apply[ResultType]
             |    lazy val default: ResultType = unsafeFrom("this is a default message")
             |    def apply(candidate: String): Either[IllegalArgumentException, ResultType] = from(candidate)
@@ -1214,10 +1204,10 @@ class RefinedSupportSpec extends AnyWordSpec with Matchers with SourceCodeFormat
             |    def unapply(candidate: String): Option[ResultType] = from(candidate).toOption
             |    def unsafeFrom(candidate: String): ResultType = rt.unsafeRefine(candidate)
             |  }
-            |  type LimitType = Option[Refined[Int, Interval.Closed[Witness.`0`.T, Witness.`20`.T]]]
+            |  type LimitType = Option[Refined[Int, Interval.Closed[0, 20]]]
             |  object LimitType {
             |    import eu.timepit.refined.api._
-            |    type ResultType = Refined[Int, Interval.Closed[Witness.`0`.T, Witness.`20`.T]]
+            |    type ResultType = Refined[Int, Interval.Closed[0, 20]]
             |    private val rt = RefinedType.apply[ResultType]
             |    lazy val default: Option[ResultType] = unsafeFrom(Some(2))
             |    def apply(candidate: Int): Either[IllegalArgumentException, Option[ResultType]] = from(Option(candidate))
@@ -1231,10 +1221,10 @@ class RefinedSupportSpec extends AnyWordSpec with Matchers with SourceCodeFormat
             |    def unapply(candidate: Option[Int]): Option[ResultType] = from(candidate).fold(_ => None, a => a)
             |    def unsafeFrom(candidate: Option[Int]): Option[ResultType] = candidate.map(rt.unsafeRefine)
             |  }
-            |  type LongIntegerType = Refined[scala.math.BigInt, LessEqual[Witness.`2147483647`.T]]
+            |  type LongIntegerType = Refined[scala.math.BigInt, LessEqual[2147483647]]
             |  object LongIntegerType {
             |    import eu.timepit.refined.api._
-            |    type ResultType = Refined[scala.math.BigInt, LessEqual[Witness.`2147483647`.T]]
+            |    type ResultType = Refined[scala.math.BigInt, LessEqual[2147483647]]
             |    private val rt = RefinedType.apply[ResultType]
             |    lazy val default: ResultType = unsafeFrom(-9223372036854775808L)
             |    def apply(candidate: scala.math.BigInt): Either[IllegalArgumentException, ResultType] = from(candidate)
@@ -1242,10 +1232,10 @@ class RefinedSupportSpec extends AnyWordSpec with Matchers with SourceCodeFormat
             |    def unapply(candidate: scala.math.BigInt): Option[ResultType] = from(candidate).toOption
             |    def unsafeFrom(candidate: scala.math.BigInt): ResultType = rt.unsafeRefine(candidate)
             |  }
-            |  type LongNumberType = Option[Refined[scala.math.BigInt, LessEqual[Witness.`2147483647`.T]]]
+            |  type LongNumberType = Option[Refined[scala.math.BigInt, LessEqual[2147483647]]]
             |  object LongNumberType {
             |    import eu.timepit.refined.api._
-            |    type ResultType = Refined[scala.math.BigInt, LessEqual[Witness.`2147483647`.T]]
+            |    type ResultType = Refined[scala.math.BigInt, LessEqual[2147483647]]
             |    private val rt = RefinedType.apply[ResultType]
             |    lazy val default: Option[ResultType] = unsafeFrom(Some(-9223372036854775808L))
             |    def apply(candidate: scala.math.BigInt): Either[IllegalArgumentException, Option[ResultType]] = from(Option(candidate))

--- a/src/test/scala/scraml/libs/TapirSupportSpec.scala
+++ b/src/test/scala/scraml/libs/TapirSupportSpec.scala
@@ -67,8 +67,8 @@ final class TapirSupportSpec
         |    }
         |  }
         |  private implicit val queryOptionalCollectionCodec: Codec[List[String], Option[scala.collection.immutable.List[String]], TextPlain] = new Codec[List[String], Option[scala.collection.immutable.List[String]], TextPlain] {
-        |    override def rawDecode(l: List[String]): DecodeResult[Option[scala.collection.immutable.List[String]]] = DecodeResult.Value(Some(l.to[scala.collection.immutable.List]))
-        |    override def encode(h: Option[scala.collection.immutable.List[String]]): List[String] = h.map(_.to[List]).getOrElse(Nil)
+        |    override def rawDecode(l: List[String]): DecodeResult[Option[scala.collection.immutable.List[String]]] = DecodeResult.Value(Some(l.to(scala.collection.immutable.List)))
+        |    override def encode(h: Option[scala.collection.immutable.List[String]]): List[String] = h.map(_.to(List)).getOrElse(Nil)
         |    override lazy val schema: Schema[Option[scala.collection.immutable.List[String]]] = Schema.binary
         |    override lazy val format: TextPlain = TextPlain()
         |  }
@@ -103,14 +103,14 @@ final class TapirSupportSpec
           """object SomeEnum {
             |  case object A extends SomeEnum
             |  case object B extends SomeEnum
-            |  case object ENUM extends SomeEnum
-            |  case object TYPE extends SomeEnum
+            |  case object enum extends SomeEnum
+            |  case object `type` extends SomeEnum
             |  import io.circe._
             |  implicit lazy val encoder: Encoder[SomeEnum] = Encoder[String].contramap {
             |    case A => "A"
             |    case B => "B"
-            |    case ENUM => "enum"
-            |    case TYPE => "type"
+            |    case `enum` => "enum"
+            |    case `type` => "type"
             |  }
             |  implicit lazy val decoder: Decoder[SomeEnum] = Decoder[String].emap {
             |    case "A" =>
@@ -118,9 +118,9 @@ final class TapirSupportSpec
             |    case "B" =>
             |      Right(B)
             |    case "enum" =>
-            |      Right(ENUM)
+            |      Right(enum)
             |    case "type" =>
-            |      Right(TYPE)
+            |      Right(`type`)
             |    case other =>
             |      Left(s"invalid enum value: $other")
             |  }
@@ -130,16 +130,16 @@ final class TapirSupportSpec
             |    case "B" =>
             |      sttp.tapir.DecodeResult.Value(B)
             |    case "enum" =>
-            |      sttp.tapir.DecodeResult.Value(ENUM)
+            |      sttp.tapir.DecodeResult.Value(enum)
             |    case "type" =>
-            |      sttp.tapir.DecodeResult.Value(TYPE)
+            |      sttp.tapir.DecodeResult.Value(`type`)
             |    case other =>
             |      sttp.tapir.DecodeResult.InvalidValue(sttp.tapir.ValidationError[String](sttp.tapir.Validator.enumeration(List("A", "B", "enum", "type")), other) :: Nil)
             |  } {
             |    case A => "A"
             |    case B => "B"
-            |    case ENUM => "enum"
-            |    case TYPE => "type"
+            |    case `enum` => "enum"
+            |    case `type` => "type"
             |  }
             |}""".stripMargin
         )
@@ -167,15 +167,15 @@ final class TapirSupportSpec
           """object SomeEnum {
             |  case object A extends SomeEnum
             |  case object B extends SomeEnum
-            |  case object ENUM extends SomeEnum
-            |  case object TYPE extends SomeEnum
+            |  case object enum extends SomeEnum
+            |  case object `type` extends SomeEnum
             |  case class Unknown(value: String) extends SomeEnum
             |  import io.circe._
             |  implicit lazy val encoder: Encoder[SomeEnum] = Encoder[String].contramap {
             |    case A => "A"
             |    case B => "B"
-            |    case ENUM => "enum"
-            |    case TYPE => "type"
+            |    case `enum` => "enum"
+            |    case `type` => "type"
             |    case Unknown(value) => value
             |  }
             |  implicit lazy val decoder: Decoder[SomeEnum] = Decoder[String].emap {
@@ -184,9 +184,9 @@ final class TapirSupportSpec
             |    case "B" =>
             |      Right(B)
             |    case "enum" =>
-            |      Right(ENUM)
+            |      Right(enum)
             |    case "type" =>
-            |      Right(TYPE)
+            |      Right(`type`)
             |    case other =>
             |      Right(Unknown(other))
             |  }
@@ -196,16 +196,16 @@ final class TapirSupportSpec
             |    case "B" =>
             |      sttp.tapir.DecodeResult.Value(B)
             |    case "enum" =>
-            |      sttp.tapir.DecodeResult.Value(ENUM)
+            |      sttp.tapir.DecodeResult.Value(enum)
             |    case "type" =>
-            |      sttp.tapir.DecodeResult.Value(TYPE)
+            |      sttp.tapir.DecodeResult.Value(`type`)
             |    case other =>
             |      sttp.tapir.DecodeResult.Value(Unknown(other))
             |  } {
             |    case A => "A"
             |    case B => "B"
-            |    case ENUM => "enum"
-            |    case TYPE => "type"
+            |    case `enum` => "enum"
+            |    case `type` => "type"
             |    case Unknown(value) => value
             |  }
             |}""".stripMargin
@@ -267,8 +267,8 @@ final class TapirSupportSpec
           |    }
           |  }
           |  private implicit val queryOptionalCollectionCodec: Codec[List[String], Option[scala.collection.immutable.List[String]], TextPlain] = new Codec[List[String], Option[scala.collection.immutable.List[String]], TextPlain] {
-          |    override def rawDecode(l: List[String]): DecodeResult[Option[scala.collection.immutable.List[String]]] = DecodeResult.Value(Some(l.to[scala.collection.immutable.List]))
-          |    override def encode(h: Option[scala.collection.immutable.List[String]]): List[String] = h.map(_.to[List]).getOrElse(Nil)
+          |    override def rawDecode(l: List[String]): DecodeResult[Option[scala.collection.immutable.List[String]]] = DecodeResult.Value(Some(l.to(scala.collection.immutable.List)))
+          |    override def encode(h: Option[scala.collection.immutable.List[String]]): List[String] = h.map(_.to(List)).getOrElse(Nil)
           |    override lazy val schema: Schema[Option[scala.collection.immutable.List[String]]] = Schema.binary
           |    override lazy val format: TextPlain = TextPlain()
           |  }


### PR DESCRIPTION
- Improve support for Scala 3 code generation using Scalameta dialects during printing
- Use literal types for refined, adding Scala 3 support and dropping 2.12 for this module
  - Also removes the shapeless dependency used for encoding literal types before
- Cross compile and run sbt scripted tests for Scala 2.13 and 3
  
This also reverts the hack to use uppercase enums from #62, as it's not needed anymore.  

## Reasoning for using dialects only during printing

Scalameta uses dialects to express differentes between Scala versions. Quasiquotes need the dialect to be fixed at compile time via import. As it runs during compile time, we can't parameterize it with a dialect dynamically. This is something we can't do here, as we want to dynamically toggle the output variant, depending on the Scala version of the project using the plugin.

On the other hand, we have a lot of code gen blocks using quasiquotes. We also have tons of Scala 2 syntax in our tests.
  
So to help keeping changes in check, we keep Scala 2 syntax in our quasiquote literals and in tests for now, i.e. we parse `q"import io.circe._")`, and only apply the dialect during pretty printing. This works fine for most things where the AST is the same. I.e. imports have the same AST representation in Scala 2 and 3, even though the syntax is different.

