### PR TITLE
Publish to new Sonatype central

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.github.sbt"   % "sbt-ci-release"     % "1.9.2")
+addSbtPlugin("com.github.sbt"   % "sbt-ci-release"     % "1.11.1")
 addSbtPlugin("org.scalameta"    % "sbt-scalafmt"       % "2.5.4")
 addSbtPlugin("com.github.sbt"   % "sbt-github-actions" % "0.24.0")
 addSbtPlugin("com.github.sbt"   % "sbt-site-paradox"   % "1.5.0")


### PR DESCRIPTION
The new version of the plugin should target it automatically. The old OSS repository has been sunset by sonatype.